### PR TITLE
ported changes for v2.2.0 firmware baseline

### DIFF
--- a/AQEV2FW_CO2_ESP.ino
+++ b/AQEV2FW_CO2_ESP.ino
@@ -473,7 +473,7 @@ const uint8_t heartbeat_waveform[NUM_HEARTBEAT_WAVEFORM_SAMPLES] PROGMEM = {
 };
 uint8_t heartbeat_waveform_index = 0;
 
-#define SCRATCH_BUFFER_SIZE (512)
+#define SCRATCH_BUFFER_SIZE (1024)
 char scratch[SCRATCH_BUFFER_SIZE] = { 0 };  // scratch buffer, for general use
 uint16_t scratch_idx = 0;
 #define ESP8266_INPUT_BUFFER_SIZE (1500)

--- a/AQEV2FW_CO2_ESP.ino
+++ b/AQEV2FW_CO2_ESP.ino
@@ -890,6 +890,7 @@ void setup() {
 
 void loop() {
   current_millis = millis();
+  static boolean first = true;
 
   // whenever you come through loop, process a GPS byte if there is one
   // will need to test if this keeps up, but I think it will
@@ -912,6 +913,11 @@ void loop() {
         break;
       }
     }
+  }
+
+  if(first && !gps_installed){
+    first = false;
+    updateGpsStrings();
   }
 
   if(current_millis - previous_sensor_sampling_millis >= sampling_interval){

--- a/AQEV2FW_CO2_ESP.ino
+++ b/AQEV2FW_CO2_ESP.ino
@@ -15,11 +15,12 @@
 #include <math.h>
 #include <TinyGPS.h>
 #include <SoftwareSerial.h>
+#include <jsmn.h>
 
 // semantic versioning - see http://semver.org/
 #define AQEV2FW_MAJOR_VERSION 2
-#define AQEV2FW_MINOR_VERSION 1
-#define AQEV2FW_PATCH_VERSION 9
+#define AQEV2FW_MINOR_VERSION 2
+#define AQEV2FW_PATCH_VERSION 0
 
 #define WLAN_SEC_AUTO (10) // made up to support auto-config of security
 
@@ -39,9 +40,16 @@ WildFire_SPIFlash flash;
 CapacitiveSensor touch = CapacitiveSensor(A0, A1);
 LiquidCrystal lcd(A3, A2, 4, 5, 6, 8);
 char g_lcd_buffer[2][17] = {0}; // 2 rows of 16 characters each, with space for NULL terminator
+char last_painted[2][17] = {"                ","                "};
+
 byte mqtt_server_ip[4] = { 0 };    
 PubSubClient mqtt_client;
 char mqtt_client_id[32] = {0};
+
+boolean wifi_can_connect = false;
+uint8_t wifi_connect_attempts = 0;
+boolean user_location_override = false;
+boolean gps_installed = false;
 
 RTC_DS3231 rtc;
 SdFat SD;
@@ -85,6 +93,10 @@ float gps_longitude = TinyGPS::GPS_INVALID_F_ANGLE;
 float gps_altitude = TinyGPS::GPS_INVALID_F_ALTITUDE;
 unsigned long gps_age = TinyGPS::GPS_INVALID_AGE;
 
+float user_latitude = TinyGPS::GPS_INVALID_F_ANGLE;
+float user_longitude = TinyGPS::GPS_INVALID_F_ANGLE;
+float user_altitude = TinyGPS::GPS_INVALID_F_ALTITUDE;
+
 #define MAX_SAMPLE_BUFFER_DEPTH (240) // 20 minutes @ 5 second resolution
 #define CO2_SAMPLE_BUFFER         (0)
 #define TEMPERATURE_SAMPLE_BUFFER (1)
@@ -102,6 +114,9 @@ float touch_sample_buffer[TOUCH_SAMPLE_BUFFER_DEPTH] = {0};
 
 #define LCD_ERROR_MESSAGE_DELAY   (4000)
 #define LCD_SUCCESS_MESSAGE_DELAY (2000)
+
+jsmn_parser parser;
+jsmntok_t json_tokens[21];
 
 boolean temperature_ready = false;
 boolean humidity_ready = false;
@@ -126,6 +141,8 @@ baseline_voltage_t baseline_voltage_struct; // scratch space for a single baseli
 #define BACKLIGHT_ALWAYS_ON      (2)
 #define BACKLIGHT_ALWAYS_OFF     (3)
 
+boolean g_backlight_turned_on = false;
+
 // the software's operating mode
 #define MODE_CONFIG      (1)
 #define MODE_OPERATIONAL (2)
@@ -148,7 +165,7 @@ uint8_t mode = MODE_OPERATIONAL;
 #define EEPROM_CONNECT_METHOD     (EEPROM_MAC_ADDRESS - 1)        // connection method encoded as a single byte value 
 #define EEPROM_SSID               (EEPROM_CONNECT_METHOD - 32)    // ssid string, up to 32 characters (one of which is a null terminator)
 #define EEPROM_NETWORK_PWD        (EEPROM_SSID - 32)              // network password, up to 32 characters (one of which is a null terminator)
-#define EEPROM_SECURITY_MODE      (EEPROM_NETWORK_PWD - 1)        // security mode encoded as a single byte value, consistent with the CC3000 library
+#define EEPROM_SECURITY_MODE      (EEPROM_NETWORK_PWD - 1)        // security mode encoded as a single byte value
 #define EEPROM_STATIC_IP_ADDRESS  (EEPROM_SECURITY_MODE - 4)      // static ipv4 address, 4 bytes - 0.0.0.0 indicates use DHCP
 #define EEPROM_STATIC_NETMASK     (EEPROM_STATIC_IP_ADDRESS - 4)  // static netmask, 4 bytes
 #define EEPROM_STATIC_GATEWAY     (EEPROM_STATIC_NETMASK - 4)     // static default gateway ip address, 4 bytes
@@ -184,6 +201,11 @@ uint8_t mode = MODE_OPERATIONAL;
 #define EEPROM_NTP_TZ_OFFSET_HRS  (EEPROM_NTP_SERVER_NAME - 4)    // timezone offset as a floating point value
 #define EEPROM_CO2_BASELINE_VOLTAGE_TABLE (EEPROM_NTP_TZ_OFFSET_HRS - (5*sizeof(baseline_voltage_t))) // array of (up to) five structures for baseline offset characterization over temperature
 #define EEPROM_MQTT_TOPIC_SUFFIX_ENABLED  (EEPROM_CO2_BASELINE_VOLTAGE_TABLE - 1) 
+#define EEPROM_USER_LATITUDE_DEG  (EEPROM_MQTT_TOPIC_SUFFIX_ENABLED - 4) // float value, 4-bytes, user specified latitude in degrees
+#define EEPROM_USER_LONGITUDE_DEG (EEPROM_USER_LATITUDE_DEG - 4)         // float value, 4-bytes, user specified longitude in degrees
+#define EEPROM_USER_LOCATION_EN   (EEPROM_USER_LONGITUDE_DEG - 1)        // 1 means user location supercedes GPS location, anything else means GPS or bust
+#define EEPROM_2_1_0_SAMPLING_UPD (EEPROM_USER_LOCATION_EN - 1)          // 1 means to sampling parameter default changes have been applied
+#define EEPROM_DISABLE_SOFTAP     (EEPROM_2_1_0_SAMPLING_UPD - 1)        // 1 means to disable softap behavior
 //  /\
 //   L Add values up here by subtracting offsets to previously added values
 //   * ... and make sure the addresses don't collide and start overlapping!
@@ -264,6 +286,10 @@ void set_ntp_timezone_offset(char * arg);
 void set_update_server_name(char * arg);
 void co2_baseline_voltage_characterization_command(char * arg);
 void topic_suffix_config(char * arg);
+void set_user_latitude(char * arg);
+void set_user_longitude(char * arg);
+void set_user_location_enable(char * arg);
+void set_softap_enable(char * arg);
 
 // Note to self:
 //   When implementing a new parameter, ask yourself:
@@ -272,7 +298,6 @@ void topic_suffix_config(char * arg);
 //     should 'init' support it (is there a way to set it without user intervention)
 //     should 'restore' support it directly
 //     should 'restore defaults' support it
-//   ... and anytime you do the above, remember to update the help_menu
 //   ... and remember, anything that changes the config EEPROM
 //       needs to call recomputeAndStoreConfigChecksum after doing so
 
@@ -321,6 +346,10 @@ const char cmd_string_altitude[] PROGMEM    = "altitude   ";
 const char cmd_string_ntpsrv[] PROGMEM      = "ntpsrv     ";
 const char cmd_string_tz_off[] PROGMEM      = "tz_off     ";
 const char cmd_string_co2_blv[] PROGMEM     = "co2_blv    ";
+const char cmd_string_usr_lat[] PROGMEM     = "latitude   ";
+const char cmd_string_usr_lng[] PROGMEM     = "longitude  ";
+const char cmd_string_usr_loc_en[] PROGMEM  = "location   ";
+const char cmd_string_softap_en[] PROGMEM   = "softap     ";
 const char cmd_string_null[] PROGMEM        = "";
 
 PGM_P const commands[] PROGMEM = {
@@ -362,6 +391,10 @@ PGM_P const commands[] PROGMEM = {
   cmd_string_ntpsrv,
   cmd_string_tz_off,
   cmd_string_co2_blv, 
+  cmd_string_usr_lat,
+  cmd_string_usr_lng,
+  cmd_string_usr_loc_en,
+  cmd_string_softap_en,
   cmd_string_null
 };
 
@@ -404,6 +437,10 @@ void (*command_functions[])(char * arg) = {
   set_ntp_server,
   set_ntp_timezone_offset,
   co2_baseline_voltage_characterization_command,
+  set_user_latitude,
+  set_user_longitude,
+  set_user_location_enable,
+  set_softap_enable,
   0
 };
 
@@ -436,7 +473,9 @@ const uint8_t heartbeat_waveform[NUM_HEARTBEAT_WAVEFORM_SAMPLES] PROGMEM = {
 };
 uint8_t heartbeat_waveform_index = 0;
 
-char scratch[1024] = { 0 };  // scratch buffer, for general use
+#define SCRATCH_BUFFER_SIZE (512)
+char scratch[SCRATCH_BUFFER_SIZE] = { 0 };  // scratch buffer, for general use
+uint16_t scratch_idx = 0;
 #define ESP8266_INPUT_BUFFER_SIZE (1500)
 uint8_t esp8266_input_buffer[ESP8266_INPUT_BUFFER_SIZE] = {0};     // sketch must instantiate a buffer to hold incoming data
                                                                    // 1500 bytes is way overkill for MQTT, but if you have it, may as well
@@ -445,6 +484,7 @@ char converted_value_string[64] = {0};
 char compensated_value_string[64] = {0};
 char raw_value_string[64] = {0};
 char raw_instant_value_string[64] = {0};
+char response_body[256] = {0};
 
 char MQTT_TOPIC_STRING[128] = {0};
 char MQTT_TOPIC_PREFIX[64] = "/orgs/wd/aqe/";
@@ -482,117 +522,176 @@ void setup() {
   if(!integrity_check_passed){
     Serial.println(F("Info: Startup config integrity check failed, attempting to restore from mirrored configuration."));
     allowed_to_write_config_eeprom = true;
-    integrity_check_passed = mirrored_config_restore_and_validate(); 
+    mirrored_config_restore_and_validate(); 
+    integrity_check_passed = checkConfigIntegrity();
+    mirrored_config_mismatch = !mirrored_config_matches_eeprom_config();
     allowed_to_write_config_eeprom = false;
   }
   else if(!mirrored_config_matches_eeprom_config()){
-    mirrored_config_mismatch = true;
+    // probably the reason you got into this case is because you changed settings 
+    // in CLI mode but failed to connect to a network afterwards
+    // so this will revert the Egg to use its last settings that *did* connect to a network
     Serial.println(F("Info: Startup config integrity check passed, but mirrored config differs, attempting to restore from mirrored configuration."));
     allowed_to_write_config_eeprom = true;
-    integrity_check_passed = mirrored_config_restore_and_validate();
+    mirrored_config_restore_and_validate(); 
+    integrity_check_passed = checkConfigIntegrity();
+    mirrored_config_mismatch = !mirrored_config_matches_eeprom_config();
     allowed_to_write_config_eeprom = false;
   }     
   
+  // possible outcomes of the above code
+  // integrity_check_passed && mirrored_config_mismatch
+  //   means... mirror configuration is not yet valid
+  // integrity_check_passed && !mirrored_config_mismatch
+  //   means... everything is great, normal behavior
+  // !integrity_check_passed && mirrored_config_mismatch
+  //   means... all attempts to attain a valid configuration faile
+  //            and the mirrored config is *different* from the eeprom config
+  // !integrity_check_passed && !mirrored_config_mismatch
+  //   means... all attempts to attain a valid configuration faile
+  //            and the mirrored config is *identical* to the eeprom config
   valid_ssid_passed = valid_ssid_config();  
-  uint8_t target_mode = eeprom_read_byte((const uint8_t *) EEPROM_OPERATIONAL_MODE);  
   boolean ok_to_exit_config_mode = true;   
   
   // if a software update introduced new settings
   // they should be populated with defaults as necessary
   initializeNewConfigSettings();
 
+  user_location_override = (eeprom_read_byte((const uint8_t *) EEPROM_USER_LOCATION_EN) == 1) ? true : false;  
+  uint8_t target_mode = eeprom_read_byte((const uint8_t *) EEPROM_OPERATIONAL_MODE);       
+
   // config mode processing loop
   do{
-    // check for initial integrity of configuration in eeprom
-    if(mode_requires_wifi(target_mode) && !valid_ssid_passed){
-      Serial.println(F("Info: No valid SSID configured, automatically falling back to CONFIG mode."));
-      configInject("aqe\r");
-      Serial.println();
-      setLCD_P(PSTR("PLEASE CONFIGURE"
-                    "NETWORK SETTINGS"));
-      mode = MODE_CONFIG;
-      allowed_to_write_config_eeprom = true;
-    }
-    else if(!integrity_check_passed && !mirrored_config_mismatch) { 
-      // if there was not a mirrored config mismatch and integrity check did not pass
-      // that means startup config integrity check failed, and restoring from mirror configuration failed
-      // to result in a valid configuration as well
-      //
-      // if, on the other hand, there was a mirrored config mismatch, the logic above *implies* that the eeprom config 
-      // is valid and that the mirrored config is not (yet) valid, so we shouldn't go into this case, and instead 
-      // we should drop into the else case (i.e. what normally happens on a startup with a valid configuration)
-      Serial.println(F("Info: Config memory integrity check failed, automatically falling back to CONFIG mode."));
-      configInject("aqe\r");
-      Serial.println();
-      setLCD_P(PSTR("CONFIG INTEGRITY"
-                    "  CHECK FAILED  "));
-      mode = MODE_CONFIG;
-      allowed_to_write_config_eeprom = true;   
-    }    
-    else {
-      // if the appropriate escape sequence is received within 8 seconds
-      // go into config mode
-      const long startup_time_period = 12000;
-      long start = millis();
-      long min_over = 100;
-      boolean got_serial_input = false;
-      Serial.println(F("Enter 'aqe' for CONFIG mode."));
-      Serial.print(F("OPERATIONAL mode automatically begins after "));
-      Serial.print(startup_time_period / 1000);
-      Serial.println(F(" secs of no input."));
-      setLCD_P(PSTR("CONNECT TERMINAL"
-                    "FOR CONFIG MODE "));
-                    
+    // if the appropriate escape sequence is received within 8 seconds
+    // go into config mode
+    const long startup_time_period = 12000;
+    long start = millis();
+    long min_over = 100;
+    boolean got_serial_input = false;
+    Serial.println(F("Enter 'aqe' for CONFIG mode."));
+    Serial.print(F("OPERATIONAL mode automatically begins after "));
+    Serial.print(startup_time_period / 1000);
+    Serial.println(F(" secs of no input."));
+    setLCD_P(PSTR(" TOUCH TO SETUP "
+                  " OR CONNECT USB "));
+    boolean soft_ap_config_activated = false;
+    boolean touch_detected = false;
+    current_millis = millis();     
+    while (current_millis < start + startup_time_period) { // can get away with this sort of thing at start up
       current_millis = millis();
-      while (current_millis < start + startup_time_period) { // can get away with this sort of thing at start up
-        current_millis = millis();
+
+      if(touch_detected && (eeprom_read_byte((uint8_t *) EEPROM_DISABLE_SOFTAP) != 1)){     
+        soft_ap_config_activated = true;
+        Serial.println();
+        Serial.println(F("Info: Entering SoftAP Mode for Configuration"));
+        break;
+      }
+
+      if(current_millis - previous_touch_sampling_millis >= touch_sampling_interval){
+        static uint8_t num_touch_intervals = 0;
+        previous_touch_sampling_millis = current_millis;    
+        collectTouch();    
+        touch_detected = processTouchQuietly();
         
-        if(current_millis - previous_touch_sampling_millis >= touch_sampling_interval){
-          static uint8_t num_touch_intervals = 0;
-          previous_touch_sampling_millis = current_millis;    
-          collectTouch();    
-          processTouchQuietly();
-          
-          num_touch_intervals++;
-          if(num_touch_intervals == 5){
-            petWatchdog(); 
-            num_touch_intervals = 0;
-          }
-          
-        }      
-      
-        if (Serial.available()) {
-          if (got_serial_input == false) {
-            Serial.println();
-          }
-          got_serial_input = true;
-  
-          start = millis(); // reset the timeout
-          if (CONFIG_MODE_GOT_INIT == configModeStateMachine(Serial.read(), false)) {
-            mode = MODE_CONFIG;
-            allowed_to_write_config_eeprom = true;
-            break;
-          }
+        num_touch_intervals++;
+        if(num_touch_intervals == 5){
+          petWatchdog(); 
+          num_touch_intervals = 0;
         }
-  
-        // output a countdown to the Serial Monitor
-        if (millis() - start >= min_over) {
-          uint8_t countdown_value_display = (startup_time_period - 500 - min_over) / 1000;
-          if (got_serial_input == false) {
-            Serial.print(countdown_value_display);
-            Serial.print(F("..."));
-          }
-          
-          updateCornerDot();
-          
-          min_over += 1000;
+        
+      }      
+    
+      if (Serial.available()) {
+        if (got_serial_input == false) {
+          Serial.println();
         }
+        got_serial_input = true;
+
+        start = millis(); // reset the timeout
+        if (CONFIG_MODE_GOT_INIT == configModeStateMachine(Serial.read(), false)) {
+          mode = MODE_CONFIG;
+          allowed_to_write_config_eeprom = true;
+          break;
+        }
+      }
+
+      // output a countdown to the Serial Monitor
+      if (millis() - start >= min_over) {
+        uint8_t countdown_value_display = (startup_time_period - 500 - min_over) / 1000;
+        if (got_serial_input == false) {
+          Serial.print(countdown_value_display);
+          Serial.print(F("..."));
+        }
+        
+        updateCornerDot();
+        
+        min_over += 1000;
       }
     }
     Serial.println();
+
+    if(soft_ap_config_activated){
+      configInject("aqe\r");
+      do{            
+        allowed_to_write_config_eeprom = true;        
+        doSoftApModeConfigBehavior();
+        valid_ssid_passed = valid_ssid_config();                                       
+      } while(!valid_ssid_passed && mode_requires_wifi(target_mode)); 
+      configInject("exit\r");
+      initEsp8266();
+    }
+    else{   
+      valid_ssid_passed = valid_ssid_config();  
+    
+      // check for initial integrity of configuration in eeprom      
+      if((mode != MODE_CONFIG) && mode_requires_wifi(target_mode) && !valid_ssid_passed){
+
+        Serial.println(F("Info: No valid SSID configured, automatically falling back to CONFIG mode."));
+        configInject("aqe\r");
+        Serial.println();
+
+        if(eeprom_read_byte((uint8_t *) EEPROM_DISABLE_SOFTAP) != 1){
+          // if you're not already in config mode, and if softap is allowed, 
+          // and if your operational mode requires wifi
+          // and if you don't have a viable ssid configured
+          // then offer the soft ap mode until you are you have a valid SSID          
+          do{            
+            allowed_to_write_config_eeprom = true;
+            doSoftApModeConfigBehavior();
+            valid_ssid_passed = valid_ssid_config();                                       
+          } while(!valid_ssid_passed);          
+        }
+        else{
+          // if you're not already in config mode, and if softap is NOT allowed, 
+          // and if your operational mode requires wifi
+          // and if you don't have a viable ssid configured
+          // then coerce terminal-based config mode
+          setLCD_P(PSTR("PLEASE CONFIGURE"
+                        "NETWORK SETTINGS"));
+          delay(LCD_ERROR_MESSAGE_DELAY);
+                    
+          configInject("aqe\r");
+          Serial.println();           
+          mode = MODE_CONFIG;                      
+        }
+      }
+      else if(!integrity_check_passed) { 
+        // we have no choice but to offer config mode to the user
+        Serial.println(F("Info: Config memory integrity check failed, automatically falling back to CONFIG mode."));
+        configInject("aqe\r");
+        Serial.println();
+        setLCD_P(PSTR("CONFIG INTEGRITY"
+                      "  CHECK FAILED  "));
+        mode = MODE_CONFIG;        
+      }          
+    }
+    
+    
+    Serial.println();
     delayForWatchdog();
     
-    if (mode == MODE_CONFIG) {      
+    while((mode == MODE_CONFIG) || (mode_requires_wifi(target_mode) && !valid_ssid_passed) ) {      
+      allowed_to_write_config_eeprom = true;   
       const uint32_t idle_timeout_period_ms = 1000UL * 60UL * 5UL; // 5 minutes
       uint32_t idle_time_ms = 0;
       Serial.println(F("-~=* In CONFIG Mode *=~-"));
@@ -604,7 +703,6 @@ void setup() {
       Serial.print((idle_timeout_period_ms / 1000UL) / 60UL);
       Serial.println(F(" mins without input."));
       Serial.println(F("Enter 'help' for a list of available commands, "));
-      get_help_indent(); Serial.println(F("...or 'help <cmd>' for help on a specific command"));
   
       configInject("get settings\r");
       Serial.println();
@@ -625,6 +723,14 @@ void setup() {
           previous_touch_sampling_millis = current_millis;   
           collectTouch();    
           processTouchQuietly();  
+        }
+
+        // check to determine if we have a GPS
+        while(!gps_installed && gpsSerial.available()){
+          char c = gpsSerial.read();
+          if(c == '$'){
+            gps_installed = true;
+          }
         }
   
         // stuck in this loop until the command line receives an exit command
@@ -651,6 +757,11 @@ void setup() {
           Serial.println(F("Info: Idle time expired, exiting CONFIG mode."));
           break;
         }
+      }
+
+      valid_ssid_passed = valid_ssid_config(); 
+      if(valid_ssid_passed){
+        break;
       }
     }
     
@@ -782,18 +893,27 @@ void loop() {
 
   // whenever you come through loop, process a GPS byte if there is one
   // will need to test if this keeps up, but I think it will
-  if(!gps_disabled){       
-    while(gpsSerial.available()){
-      if(gps.encode(gpsSerial.read())){
+  if(user_location_override){
+    // hardware doesn't matter in this case
+    updateGpsStrings();
+  }
+  else if(!gps_disabled){       
+    while(gpsSerial.available()){            
+      char c = gpsSerial.read();
+
+      if(c == '$'){
+        gps_installed = true;
+      }
+      
+      if(gps.encode(c)){
         gps.f_get_position(&gps_latitude, &gps_longitude, &gps_age);
         gps_altitude = gps.f_altitude();
-        updateGpsStrings();
+        updateGpsStrings();        
         break;
       }
     }
-  }
-  
-
+  }   
+    
   if(current_millis - previous_sensor_sampling_millis >= sampling_interval){
     suspendGpsProcessing();
     previous_sensor_sampling_millis = current_millis;    
@@ -855,6 +975,23 @@ void init_firmware_version(void){
     AQEV2FW_PATCH_VERSION);
 }
 
+void initEsp8266(void){
+  uint8_t connect_method = eeprom_read_byte((const uint8_t *) EEPROM_CONNECT_METHOD);
+  Serial.print(F("Info: ESP8266 Initialization..."));  
+    
+  esp.setTcpKeepAliveInterval(10); // 10 seconds
+  esp.setInputBuffer(esp8266_input_buffer, ESP8266_INPUT_BUFFER_SIZE); // connect the input buffer up   
+  if (esp.reset()) {
+    esp.setNetworkMode(1);
+    Serial.println(F("OK."));
+    init_esp8266_ok = true;
+  }
+  else {
+    Serial.println(F("Failed."));
+    init_esp8266_ok = false;
+  }  
+}
+
 void initializeHardware(void) {
   Serial.begin(115200);
   Serial1.begin(115200);
@@ -864,6 +1001,7 @@ void initializeHardware(void) {
   // without this line, if the touch hardware is absent
   // serial input processing grinds to a snails pace
   touch.set_CS_Timeout_Millis(100); 
+  touch.set_CS_AutocaL_Millis(5000);
 
   Serial.println(F(" +------------------------------------+"));
   Serial.println(F(" |   Welcome to Air Quality Egg 2.0   |"));
@@ -1012,23 +1150,10 @@ void initializeHardware(void) {
 
   selectNoSlot();
 
-  uint8_t connect_method = eeprom_read_byte((const uint8_t *) EEPROM_CONNECT_METHOD);
-  Serial.print(F("Info: ESP8266 Initialization..."));  
-  SUCCESS_MESSAGE_DELAY(); // don't race past the splash screen, and give watchdog some breathing room
   petWatchdog();
+  SUCCESS_MESSAGE_DELAY(); // don't race past the splash screen, and give watchdog some breathing room
+  initEsp8266();
     
-  esp.setTcpKeepAliveInterval(10); // 10 seconds
-  esp.setInputBuffer(esp8266_input_buffer, ESP8266_INPUT_BUFFER_SIZE); // connect the input buffer up   
-  if (esp.reset()) {
-    esp.setNetworkMode(1);
-    Serial.println(F("OK."));
-    init_esp8266_ok = true;
-  }
-  else {
-    Serial.println(F("Failed."));
-    init_esp8266_ok = false;
-  }
-
   updateLCD("CO2", 0);
   updateLCD("MODEL", 1);
   SUCCESS_MESSAGE_DELAY();
@@ -1092,6 +1217,27 @@ void initializeNewConfigSettings(void){
     memset(command_buf, 0, 128);
     strcat(command_buf, "mqttsuffix enable\r");        
     configInject(command_buf);    
+  }
+  
+  val = eeprom_read_byte((const uint8_t *) EEPROM_2_1_0_SAMPLING_UPD);
+  if(val != 1){
+    if(!in_config_mode){
+      configInject("aqe\r");
+      in_config_mode = true;
+    }
+
+    configInject("softap enable\r");                
+    configInject("sampling 5, 60, 60\r");
+    eeprom_write_byte((uint8_t *) EEPROM_2_1_0_SAMPLING_UPD, 1);
+
+    // check if ntpsrv is pool.ntp.org, and if so, switch it to 0.airqualityegg.pool.ntp.org
+    memset(command_buf, 0, 128);  
+    eeprom_write_block(command_buf, (void *) EEPROM_NTP_SERVER_NAME, 32);
+    if(strcmp(command_buf, "pool.ntp.org") == 0){      
+      configInject("ntpsrv 0.airqualityegg.pool.ntp.org\r");
+    }    
+    
+    recomputeAndStoreConfigChecksum();
   }
   
   if(in_config_mode){
@@ -1215,6 +1361,9 @@ uint8_t configModeStateMachine(char b, boolean reset_buffers) {
       // deal with commands that can legitimately have no arguments first
       if (strncmp("help", lower_buf, 4) == 0) {
         help_menu(first_arg);
+      }
+      else if(strncmp("pwd", lower_buf, 3) == 0) {
+        set_network_password(first_arg);
       }
       else if (first_arg != 0) {
         //Serial.print(F("Received Command: \""));
@@ -1357,336 +1506,7 @@ void help_menu(char * arg) {
     Serial.println();
   }
   else {
-    // we have an argument, so the user is asking for some specific usage instructions
-    // as they pertain to this command
-    if (strncmp("help", arg, 4) == 0) {
-      Serial.println(F("help <param>"));
-      Serial.println(F("   <param> is any legal command keyword"));
-      Serial.println(F("   result: usage instructions are printed"));
-      Serial.println(F("           for the command named <arg>"));
-    }
-    else if (strncmp("exit", arg, 4) == 0) {
-      Serial.println(F("exit"));
-      get_help_indent(); Serial.println(F("exits CONFIG mode and begins OPERATIONAL mode."));
-    }
-    else if (strncmp("get", arg, 3) == 0) {
-      Serial.println(F("get <param>"));
-      get_help_indent(); Serial.println(F("<param> is one of:"));
-      get_help_indent(); Serial.println(F("settings - displays all viewable settings"));
-      get_help_indent(); Serial.println(F("mac - the MAC address of the ESP8266"));
-      get_help_indent(); Serial.println(F("method - the Wi-Fi connection method"));
-      get_help_indent(); Serial.println(F("ssid - the Wi-Fi SSID to connect to"));
-      get_help_indent(); Serial.println(F("pwd - lol, sorry, that's not happening!"));
-      get_help_indent(); Serial.println(F("security - the Wi-Fi security mode"));
-      get_help_indent(); Serial.println(F("ipmode - the Wi-Fi IP-address mode"));
-      get_help_indent(); Serial.println(F("mqttsrv - MQTT server name"));
-      get_help_indent(); Serial.println(F("mqttport - MQTT server port"));           
-      get_help_indent(); Serial.println(F("mqttuser - MQTT username"));
-      get_help_indent(); Serial.println(F("mqttpwd - lol, sorry, that's not happening either!"));      
-      get_help_indent(); Serial.println(F("mqttid - MQTT client ID"));      
-      get_help_indent(); Serial.println(F("mqttauth - MQTT authentication enabled?"));      
-      get_help_indent(); Serial.println(F("updatesrv - Update server name"));      
-      get_help_indent(); Serial.println(F("updatefile - Update filename (no extension)"));          
-      get_help_indent(); Serial.println(F("co2_off - CO2 sensors offset [V]"));
-      get_help_indent(); Serial.println(F("temp_off - Temperature sensor reporting offset [degC] (subtracted)"));
-      get_help_indent(); Serial.println(F("hum_off - Humidity sensor reporting offset [%] (subtracted)"));      
-      get_help_indent(); Serial.println(F("key - lol, sorry, that's also not happening!"));
-      get_help_indent(); Serial.println(F("opmode - the Operational Mode the Egg is configured for"));
-      get_help_indent(); Serial.println(F("tempunit - the unit of measure Temperature is reported in (F or C)"));      
-      get_help_indent(); Serial.println(F("backlight - the backlight behavior settings (duration, mode)"));
-      get_help_indent(); Serial.println(F("timestamp - the current timestamp in the format m/d/y h:m:s"));
-      get_help_indent(); Serial.println(F("sampleint - the sensor sampling interval in seconds"));
-      get_help_indent(); Serial.println(F("reportint - the reporting sampling interval in seconds"));
-      get_help_indent(); Serial.println(F("avgint - the sensor averaging interval in seconds"));
-      get_help_indent(); Serial.println(F("altitude - the altitude of the sensor in meters above sea level"));
-      get_help_indent(); Serial.println(F("ntpsrv - the NTP server name"));
-      get_help_indent(); Serial.println(F("tz_off - the timezone offset for use with NTP in decimal hours"));      
-      get_help_indent(); Serial.println(F("co2_blv - the co2 baseline voltage characterization"));
-      get_help_indent(); Serial.println(F("result: the current, human-readable, value of <param>"));
-      get_help_indent(); Serial.println(F("        is printed to the console."));
-    }
-    else if (strncmp("init", arg, 4) == 0) {
-      Serial.println(F("init <param>"));
-      get_help_indent(); Serial.println(F("<param> is one of:"));
-      get_help_indent(); Serial.println(F("mac         - retrieves the mac address from"));
-      get_help_indent(); Serial.println(F("                 the ESP8266 and stores it in EEPROM"));
-    }
-    else if (strncmp("restore", arg, 7) == 0) {
-      Serial.println(F("restore <param>"));
-      get_help_indent(); Serial.println(F("<param> is one of:"));
-      
-      get_help_indent(); Serial.println(F("defaults -   performs:"));
-      defaults_help_indent(); Serial.println(F("method direct"));
-      defaults_help_indent(); Serial.println(F("security wpa2"));
-      defaults_help_indent(); Serial.println(F("use dhcp"));
-      defaults_help_indent(); Serial.println(F("opmode normal"));
-      defaults_help_indent(); Serial.println(F("tempunit C"));   
-      defaults_help_indent(); Serial.println(F("altitude -1")); 
-      defaults_help_indent(); Serial.println(F("backlight 60"));
-      defaults_help_indent(); Serial.println(F("backlight initon"));      
-      defaults_help_indent(); Serial.println(F("mqttsrv mqtt.opensensors.io"));
-      defaults_help_indent(); Serial.println(F("mqttport 1883"));           
-      defaults_help_indent(); Serial.println(F("mqttauth enable"));        
-      defaults_help_indent(); Serial.println(F("mqttuser wickeddevice"));  
-      defaults_help_indent(); Serial.println(F("mqttprefix /orgs/wd/aqe/")); 
-      defaults_help_indent(); Serial.println(F("sampling 5, 30, 5"));
-      defaults_help_indent(); Serial.println(F("mqttsuffix enable"));
-      defaults_help_indent(); Serial.println(F("ntpsrv disable"));
-      defaults_help_indent(); Serial.println(F("ntpsrv pool.ntp.org"));
-      defaults_help_indent(); Serial.println(F("restore tz_off"));
-      defaults_help_indent(); Serial.println(F("restore temp_off"));      
-      defaults_help_indent(); Serial.println(F("restore hum_off"));          
-      defaults_help_indent(); Serial.println(F("restore mac"));
-      defaults_help_indent(); Serial.println(F("restore mqttpwd"));
-      defaults_help_indent(); Serial.println(F("restore mqttid"));      
-      defaults_help_indent(); Serial.println(F("restore updatesrv"));   
-      defaults_help_indent(); Serial.println(F("restore updatefile"));         
-      defaults_help_indent(); Serial.println(F("restore key"));
-      defaults_help_indent(); Serial.println(F("restore co2'"));
-      defaults_help_indent(); Serial.println(F("clears the SSID from memory"));
-      defaults_help_indent(); Serial.println(F("clears the Network Password from memory"));
-      get_help_indent(); Serial.println(F("mac        - retrieves the mac address from BACKUP"));
-      get_help_indent(); Serial.println(F("mqttpwd    - restores the MQTT password from BACKUP "));
-      get_help_indent(); Serial.println(F("mqttid     - restores the MQTT client ID"));    
-      get_help_indent(); Serial.println(F("updatesrv  - restores the Update server name"));          
-      get_help_indent(); Serial.println(F("updatefile - restores the Update filename"));           
-      get_help_indent(); Serial.println(F("key        - restores the Private Key from BACKUP "));
-      get_help_indent(); Serial.println(F("co2         - restores the CO2 calibration parameters from BACKUP "));
-      get_help_indent(); Serial.println(F("temp_off   - restores the Temperature reporting offset from BACKUP "));
-      get_help_indent(); Serial.println(F("hum_off    - restores the Humidity reporting offset from BACKUP "));      
-    }
-    else if (strncmp("mac", arg, 3) == 0) {
-      Serial.println(F("mac <address>"));
-      get_help_indent(); Serial.println(F("<address> is a MAC address of the form:"));
-      get_help_indent(); Serial.println(F("             08:ab:73:DA:8f:00"));
-      warn_could_break_connect();
-    }
-    else if (strncmp("method", arg, 6) == 0) {
-      Serial.println(F("method <type>"));
-      get_help_indent(); Serial.println(F("<type> is one of:"));
-      get_help_indent(); Serial.println(F("direct - use parameters entered in CONFIG mode"));      
-      warn_could_break_connect();      
-    }
-    else if (strncmp("ssid", arg, 4) == 0) {
-      Serial.println(F("ssid <string>"));
-      get_help_indent(); Serial.println(F("<string> is the SSID of the network the device should connect to."));
-      warn_could_break_connect();      
-    }
-    else if (strncmp("pwd", arg, 3) == 0) {
-      Serial.println(F("pwd <string>"));
-      get_help_indent(); Serial.println(F("<string> is the network password for "));
-      get_help_indent(); Serial.println(F("the SSID that the device should connect to."));
-      warn_could_break_connect();      
-    }
-    else if (strncmp("security", arg, 8) == 0) {
-      Serial.println(F("security <mode>"));
-      get_help_indent(); Serial.println(F("<mode> is one of:"));
-      get_help_indent(); Serial.println(F("open - the network is unsecured"));
-      get_help_indent(); Serial.println(F("wep  - the network WEP security"));
-      get_help_indent(); Serial.println(F("wpa  - the network WPA Personal security"));
-      get_help_indent(); Serial.println(F("wpa2 - the network WPA2 Personal security"));
-      get_help_indent(); Serial.println(F("auto - determine during first network successful scan"));      
-      warn_could_break_connect();      
-    }
-    else if (strncmp("staticip", arg, 8) == 0) {
-      Serial.println(F("staticip <config>"));
-      Serial.println(F("   <config> is four ip addresses separated by spaces"));
-      get_help_indent(); Serial.println(F("<param1> static ip address, e.g. 192.168.1.17"));
-      get_help_indent(); Serial.println(F("<param2> netmask, e.g. 255.255.255.0"));      
-      get_help_indent(); Serial.println(F("<param3> default gateway ip address, e.g. 192.168.1.1"));      
-      get_help_indent(); Serial.println(F("<param4> dns server ip address, e.g. 8.8.8.8"));      
-      get_help_indent(); Serial.println(F("result: The entered static network parameters will be used by the ESP8266"));
-      get_help_indent(); Serial.println(F("note:   To configure DHCP use command 'use dhcp'"));
-      warn_could_break_connect();      
-    }
-    else if (strncmp("use", arg, 3) == 0) {
-      Serial.println(F("use <param>"));
-      get_help_indent(); Serial.println(F("<param> is one of:"));
-      get_help_indent(); Serial.println(F("dhcp - wipes the Static IP address from the EEPROM"));
-      get_help_indent(); Serial.println(F("ntp - enables NTP capabilities"));
-      warn_could_break_connect();      
-    }
-    else if (strncmp("list", arg, 4) == 0) {
-      Serial.println(F("list <param>"));
-      get_help_indent(); Serial.println(F("<param> is one of:"));
-      get_help_indent(); Serial.println(F("files - lists all files on the sd card (if inserted)"));   
-    }
-    else if (strncmp("download", arg, 8) == 0) {
-      Serial.println(F("download <filename>"));
-      get_help_indent(); Serial.println(F("prints the contents of the named file to the console."));
-      Serial.println(F("download <YYMMDDHH> <YYMMDDHH>"));      
-      get_help_indent(); Serial.println(F("prints the contents of files from start to end dates inclusive."));
-    }   
-    else if (strncmp("delete", arg, 6) == 0) {
-      Serial.println(F("delete <filename>"));
-      get_help_indent(); Serial.println(F("deletes the named file from the SD card."));
-      Serial.println(F("delete <YYMMDDHH> <YYMMDDHH>"));      
-      get_help_indent(); Serial.println(F("deletes the files from start to end dates inclusive."));
-    }       
-    else if (strncmp("force", arg, 5) == 0) {
-      Serial.println(F("force <param>"));
-      get_help_indent(); Serial.println(F("<param> is one of:"));
-      get_help_indent(); Serial.println(F("update - invalidates the firmware signature, "));
-      get_help_indent(); Serial.println(F("         configures for normal mode, and exits config mode, "));
-      get_help_indent(); Serial.println(F("         and should initiate firmware update after connecting to wi-fi."));
-    }    
-    else if (strncmp("sampling", arg, 8) == 0) {
-      Serial.println(F("sampling <sampling_interval>, <averaging_interval>, <reporting_interval>"));
-      get_help_indent(); Serial.println(F("<sampling_interval> is the duration between sensor samples, in integer seconds (at least 3)"));
-      get_help_indent(); Serial.println(F("<averaging_interval> is the duration that is averaged in reporting, in seconds (multiple of sample interval)"));
-      get_help_indent(); Serial.println(F("<reporting_interval> is the duration between sensor reports (wifi/console/sd/etc.), in seconds (multiple of sample interval)"));
-    }
-    else if (strncmp("mqttpwd", arg, 7) == 0) {
-      Serial.println(F("mqttpwd <string>"));
-      get_help_indent(); Serial.println(F("<string> is the password the device will use to connect "));
-      get_help_indent(); Serial.println(F("to the MQTT server."));
-      note_know_what_youre_doing();
-      warn_could_break_upload();      
-    }
-    else if (strncmp("mqttsrv", arg, 7) == 0) {
-      Serial.println(F("mqttsrv <string>"));
-      get_help_indent(); Serial.println(F("<string> is the DNS name of the MQTT server."));
-      note_know_what_youre_doing();
-      warn_could_break_upload();  
-    }
-    else if (strncmp("mqttuser", arg, 8) == 0) {
-      Serial.println(F("mqttuser <string>"));
-      get_help_indent(); Serial.println(F("<string> is the username used to connect to the MQTT server."));
-      note_know_what_youre_doing();
-      warn_could_break_upload();  
-    }
-    else if (strncmp("mqttid", arg, 6) == 0) {
-      Serial.println(F("mqttid <string>"));
-      get_help_indent(); Serial.println(F("<string> is the Client ID used to connect to the MQTT server."));
-      get_help_indent(); Serial.println(F("Must be between 1 and 23 characters long per MQTT v3.1 spec."));    
-      // Ref: http://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html#connect  
-      note_know_what_youre_doing();
-      warn_could_break_upload();  
-    }    
-    else if (strncmp("mqttauth", arg, 8) == 0) {
-      Serial.println(F("mqttauth <string>"));
-      get_help_indent(); Serial.println(F("<string> is the one of 'enable' or 'disable'"));
-      note_know_what_youre_doing();
-      warn_could_break_upload();   
-    }        
-    else if (strncmp("mqttprefix", arg, 10) == 0) {
-      Serial.println(F("mqttprefix <string>"));
-      get_help_indent(); Serial.println(F("<string> is pre-pended to the logical topic for each sensor"));
-      note_know_what_youre_doing();
-      warn_could_break_upload();   
-    }        
-    else if (strncmp("mqttsuffix", arg, 10) == 0) {
-      Serial.println(F("mqttsuffix <string>"));
-      get_help_indent(); Serial.println(F("<string> is 'enable' or 'disable'"));
-      get_help_indent(); Serial.println(F("if enabled, appends the device ID to each topic"));
-      note_know_what_youre_doing();
-      warn_could_break_upload();   
-    }    
-    else if (strncmp("mqttport", arg, 8) == 0) {
-      Serial.println(F("mqttport <number>"));
-      get_help_indent(); Serial.println(F("<number> is the a number between 1 and 65535 inclusive"));
-      note_know_what_youre_doing();
-      warn_could_break_upload();  
-    }            
-    else if (strncmp("updatesrv", arg, 9) == 0) {
-      Serial.println(F("updatesrv <string>"));
-      get_help_indent(); Serial.println(F("<string> is the DNS name of the Update server."));
-      get_help_indent(); Serial.println(F("note: to disable internet firmware updates type 'updatesrv disable'"));
-      get_help_indent(); Serial.println(F("      to re-enable internet firmware updates type 'restore updatesrv'"));
-      get_help_indent(); Serial.println(F("warning: Using this command incorrectly can prevent your device"));
-      get_help_indent(); Serial.println(F("         from getting firmware updates over the internet."));
-    }   
-    else if (strncmp("ntpsrv", arg, 6) == 0) {
-      Serial.println(F("ntpsrv <string>"));
-      get_help_indent(); Serial.println(F("<string> is the DNS name of the Update server."));
-      get_help_indent(); Serial.println(F("note: to disable NTP type 'ntpsrv disable'"));      
-    }   
-    else if (strncmp("updatefile", arg, 10) == 0) {
-      Serial.println(F("updatefile <string>"));
-      get_help_indent(); Serial.println(F("<string> is the filename to load from the Update server, excluding the extension."));
-      get_help_indent(); Serial.println(F("note:    Unless you *really* know what you're doing, you should"));
-      get_help_indent(); Serial.println(F("         probably not be using this command."));
-      get_help_indent(); Serial.println(F("warning: Using this command incorrectly can prevent your device"));
-      get_help_indent(); Serial.println(F("         from getting firmware updates over the internet."));
-    }    
-    else if (strncmp("backup", arg, 6) == 0) {
-      Serial.println(F("backup <param>"));
-      get_help_indent(); Serial.println(F("<param> is one of:"));
-      get_help_indent(); Serial.println(F("mqttpwd  - backs up the MQTT password"));
-      get_help_indent(); Serial.println(F("mac      - backs up the ESP8266 MAC address"));
-      get_help_indent(); Serial.println(F("key      - backs up the 256-bit private key"));
-      get_help_indent(); Serial.println(F("co2      - backs up the CO2 calibration parameters"));    
-      get_help_indent(); Serial.println(F("temp     - backs up the Temperature calibration parameters"));
-      get_help_indent(); Serial.println(F("hum      - backs up the Humidity calibration parameters"));  
-      get_help_indent(); Serial.println(F("tz       - backs up the Timezone offset for NTP"));    
-      get_help_indent(); Serial.println(F("all      - does all of the above"));
-    }
-    else if (strncmp("co2_off", arg, 7) == 0) {
-      Serial.println(F("co2_off <number>"));
-      Serial.println(F("   <number> is the decimal value of CO2 sensor offset [V]"));
-    }
-    else if (strncmp("temp_off", arg, 8) == 0) {
-      Serial.println(F("temp_off <number>"));
-      get_help_indent(); Serial.println(F("<number> is the decimal value of Temperature sensor reporting offset [degC] (subtracted)"));
-    }
-    else if (strncmp("hum_off", arg, 7) == 0) {
-      Serial.println(F("hum_off <number>"));
-      get_help_indent(); Serial.println(F("<number> is the decimal value of Humidity sensor reporting offset [%] (subtracted)"));
-    }    
-    else if (strncmp("key", arg, 3) == 0) {
-      Serial.println(F("key <string>"));
-      get_help_indent(); Serial.println(F("<string> is a 64-character string representing "));
-      get_help_indent(); Serial.println(F("a 32-byte (256-bit) hexadecimal value of the private key"));
-    }
-    else if (strncmp("opmode", arg, 6) == 0) {
-      Serial.println(F("opmode <mode>"));
-      get_help_indent(); Serial.println(F("<mode> is one of:"));
-      get_help_indent(); Serial.println(F("normal - publish data to MQTT server over Wi-Fi"));
-      get_help_indent(); Serial.println(F("offline - this mode writes data to an installed microSD card, creating one file per hour, "));
-      Serial.println(F("                named by convention YYMMDDHH.csv, intended to be used in conjunction with RTC module"));
-    }    
-    else if (strncmp("tempunit", arg, 8) == 0) {
-      Serial.println(F("tempunit <unit>"));
-      get_help_indent(); Serial.println(F("<unit> is one of:"));      
-      get_help_indent(); Serial.println(F("C - report temperature in Celsius"));
-      get_help_indent(); Serial.println(F("F - report temperature in Fahrenheit"));
-    }
-    else if (strncmp("altitude", arg, 8) == 0) {
-      Serial.println(F("altitude <number>"));
-      get_help_indent(); Serial.println(F("<number> is the height above sea level where the Egg is [meters]"));   
-      get_help_indent(); Serial.println(F("Note: -1 is a special value meaning do not apply pressure compensation"));
-    }    
-    else if (strncmp("datetime", arg, 8) == 0) {
-      Serial.println(F("datetime <csv-date-time>"));
-      get_help_indent(); Serial.println(F("<csv-date-time> is a comma separated date in the order year, month, day, hours, minutes, seconds"));    
-    }
-    else if(strncmp("tz_off", arg, 6) == 0){
-      Serial.println(F("tz_off <number>"));
-      get_help_indent(); Serial.println(F("<number> is the decimal value of the timezone offset in hours from GMT"));
-    }
-    else if (strncmp("co2_blv", arg, 7) == 0) {
-      get_help_indent(); Serial.println(F("<sub-command> is one of 'add', 'clear', 'show'"));
-      get_help_indent(); Serial.println(F("co2_blv add [temperature] [slope] [intercept]"));
-      get_help_indent(); Serial.println(F("    adds a row to the characterization table"));
-      get_help_indent(); Serial.println(F("co2_blv show"));
-      get_help_indent(); Serial.println(F("    displays the current characterization table"));
-      get_help_indent(); Serial.println(F("co2_blv clear"));
-      get_help_indent(); Serial.println(F("    erases the contents of the characterization table"));
-    }
-    else if (strncmp("backlight", arg, 9) == 0){
-      Serial.println(F("backlight <config>"));
-      get_help_indent(); Serial.println(F("<config> is one of:"));      
-      get_help_indent(); Serial.println(F("<seconds> - the whole number interval, in seconds, to keep the backlight on for when engaged"));
-      get_help_indent(); Serial.println(F("initoff - makes the backlight off at startup"));      
-      get_help_indent(); Serial.println(F("initon - makes the backlight on at startup"));            
-      get_help_indent(); Serial.println(F("alwayson - makes the backlight always on"));            
-      get_help_indent(); Serial.println(F("alwaysoff - makes the backlight always off"));                  
-    }
-    else {
-      Serial.print(F("Error: There is no help available for command \""));
-      Serial.print(arg);
-      Serial.println(F("\""));
-    }
+    Serial.println(F("Please visit http://airqualityegg.wickeddevice.com/help for command line usage details"));
   }
 }
 
@@ -1772,10 +1592,10 @@ void print_eeprom_security_type(void) {
       Serial.println(F("WEP"));
       break;
     case 2:
-      Serial.println(F("WPA"));
+      Serial.println(F("WPA2"));
       break;
     case 3:
-      Serial.println(F("WPA2"));
+      Serial.println(F("WPA"));
       break;
     case WLAN_SEC_AUTO:
       Serial.println(F("Automatic - Not Yet Determined"));
@@ -1988,6 +1808,30 @@ void print_altitude_settings(void){
   }
 }
 
+void print_latitude_settings(void){
+  int16_t l_latitude = (int16_t) eeprom_read_word((uint16_t *) EEPROM_USER_LATITUDE_DEG);
+  float f_latitude = eeprom_read_float((float *) EEPROM_USER_LATITUDE_DEG);
+  if(l_latitude != -1){
+    Serial.print(f_latitude, 6);
+    Serial.println(F(" degrees"));  
+  }
+  else{
+    Serial.println("Not set");
+  }
+}
+
+void print_longitude_settings(void){
+  int16_t l_longitude = (int16_t) eeprom_read_word((uint16_t *) EEPROM_USER_LONGITUDE_DEG);
+  float f_longitude = eeprom_read_float((float *) EEPROM_USER_LONGITUDE_DEG);
+  if(l_longitude != -1){
+    Serial.print(f_longitude, 6);
+    Serial.println(F(" degrees"));  
+  }
+  else{
+    Serial.println("Not set");
+  }
+}
+
 void print_eeprom_backlight(){   
   uint16_t backlight_duration = eeprom_read_word((uint16_t *) EEPROM_BACKLIGHT_DURATION);
   uint8_t backlight_startup = eeprom_read_byte((uint8_t *) EEPROM_BACKLIGHT_STARTUP);
@@ -2083,6 +1927,12 @@ void print_eeprom_value(char * arg) {
   else if(strncmp(arg, "altitude", 8) == 0) {
     Serial.println((int16_t) eeprom_read_word((uint16_t *) EEPROM_ALTITUDE_METERS));    
   }         
+  else if(strncmp(arg, "latitude", 8) == 0) {
+    Serial.println((int16_t) eeprom_read_float((float *) EEPROM_USER_LATITUDE_DEG));    
+  }
+  else if(strncmp(arg, "longitude", 8) == 0) {
+    Serial.println((int16_t) eeprom_read_float((float *) EEPROM_USER_LONGITUDE_DEG));    
+  }             
   else if(strncmp(arg, "settings", 8) == 0) {
     // print all the settings to the screen in an orderly fashion
     Serial.println(F(" +-------------------------------------------------------------+"));
@@ -2092,8 +1942,6 @@ void print_eeprom_value(char * arg) {
     print_eeprom_operational_mode(eeprom_read_byte((const uint8_t *) EEPROM_OPERATIONAL_MODE));
     Serial.print(F("    Temperature Units: "));
     print_eeprom_temperature_units();
-    Serial.print(F("    Altitude: "));
-    print_altitude_settings();
     Serial.print(F("    Backlight Settings: "));
     print_eeprom_backlight();
     Serial.print(F("    Sensor Sampling Interval: "));
@@ -2105,6 +1953,40 @@ void print_eeprom_value(char * arg) {
     Serial.print(F("    Sensor Reporting Interval: "));
     Serial.print(eeprom_read_word((uint16_t *) EEPROM_REPORTING_INTERVAL));  
     Serial.println(F(" seconds"));
+    Serial.print(F("    SoftAP Config: "));
+    if(eeprom_read_byte((const uint8_t *) EEPROM_DISABLE_SOFTAP) == 1){
+      Serial.println(F("Disabled"));
+    }
+    else{
+      Serial.println(F("Enabled"));
+    }
+
+    Serial.println(F(" +-------------------------------------------------------------+"));
+    Serial.println(F(" | Location Settings:                                          |"));
+    Serial.println(F(" +-------------------------------------------------------------+"));
+
+    Serial.print(F("    User Location: "));
+    if(eeprom_read_byte((uint8_t *) EEPROM_USER_LOCATION_EN) == 1){
+      Serial.println(F("Enabled"));
+    }
+    else{
+      Serial.println(F("Disabled"));
+    }  
+
+    Serial.print(F("    GPS: "));
+    if(gps_installed){
+      Serial.println(F("Installed"));
+    }
+    else{
+      Serial.println(F("Not installed"));
+    } 
+ 
+    Serial.print(F("    User Latitude: "));
+    print_latitude_settings();
+    Serial.print(F("    User Longitude: "));
+    print_longitude_settings();
+    Serial.print(F("    User Altitude: "));
+    print_altitude_settings();    
     
     Serial.println(F(" +-------------------------------------------------------------+"));
     Serial.println(F(" | Network Settings:                                           |"));
@@ -2231,6 +2113,7 @@ void restore(char * arg) {
 
   if (strncmp(arg, "defaults", 8) == 0) {
     prompt();
+    configInject("softap enable\r");
     configInject("method direct\r");
     configInject("security auto\r");
     configInject("use dhcp\r");
@@ -2245,9 +2128,9 @@ void restore(char * arg) {
     configInject("mqttuser wickeddevice\r");
     configInject("mqttprefix /orgs/wd/aqe/\r");
     configInject("mqttsuffix enable\r");
-    configInject("sampling 5, 30, 5\r");   
+    configInject("sampling 5, 60, 60\r"); // sample every 5 seconds, average over 1 minutes, report every minute
     configInject("ntpsrv disable\r");
-    configInject("ntpsrv pool.ntp.org\r");
+    configInject("ntpsrv 0.airqualityegg.pool.ntp.org\r");
     configInject("restore tz_off\r");
     configInject("restore temp_off\r");
     configInject("restore hum_off\r");       
@@ -2501,7 +2384,7 @@ void sampling_command(char * arg){
       case 0:
         l_sample_interval = (uint16_t) strtoul(token, NULL, 10);
         if(l_sample_interval < 1){
-          Serial.print(F("Error: Sampling interval must be greater than 1 [was ")); 
+          Serial.print(F("Error: Sampling interval must be greater than 0 [was ")); 
           Serial.print(l_sample_interval);
           Serial.print(F("]"));
           Serial.println();
@@ -2796,6 +2679,7 @@ void set_network_security_mode(char * arg) {
   boolean valid = true;
   if (strncmp("open", arg, 4) == 0) {
     eeprom_write_byte((uint8_t *) EEPROM_SECURITY_MODE, 0);
+    set_network_password("");
   }
   else if (strncmp("wep", arg, 3) == 0) {
     eeprom_write_byte((uint8_t *) EEPROM_SECURITY_MODE, 1);
@@ -3234,6 +3118,61 @@ void set_mqtt_topic_prefix(char * arg) {
     Serial.println(F("Error: MQTT prefix must be less than 64 characters in length"));
   }
 }
+
+void set_user_latitude(char * arg){
+  set_float_param(arg, (float *) EEPROM_USER_LATITUDE_DEG, NULL);
+}
+
+void set_user_longitude(char * arg){
+  set_float_param(arg, (float *) EEPROM_USER_LONGITUDE_DEG, NULL);  
+}
+
+void set_user_location_enable(char * arg){
+  if(!configMemoryUnlocked(__LINE__)){
+    return;
+  }
+
+  lowercase(arg);
+  
+  if (strcmp(arg, "enable") == 0){
+    eeprom_write_byte((uint8_t *) EEPROM_USER_LOCATION_EN, 1);    
+    recomputeAndStoreConfigChecksum();
+  }
+  else if (strcmp(arg, "disable") == 0){
+    eeprom_write_byte((uint8_t *) EEPROM_USER_LOCATION_EN, 0);
+    recomputeAndStoreConfigChecksum();
+  }
+  else {
+    Serial.print(F("Error: expected 'enable' or 'disable' but got '"));
+    Serial.print(arg);
+    Serial.println("'");
+  }  
+
+  user_location_override = eeprom_read_byte((uint8_t *) EEPROM_USER_LOCATION_EN) == 1 ? true : false;
+}
+
+void set_softap_enable(char * arg){
+  if(!configMemoryUnlocked(__LINE__)){
+    return;
+  }
+
+  lowercase(arg);
+  
+  if (strcmp(arg, "enable") == 0){
+    eeprom_write_byte((uint8_t *) EEPROM_DISABLE_SOFTAP, 0);    
+    recomputeAndStoreConfigChecksum();
+  }
+  else if (strcmp(arg, "disable") == 0){
+    eeprom_write_byte((uint8_t *) EEPROM_DISABLE_SOFTAP, 1);
+    recomputeAndStoreConfigChecksum();
+  }
+  else {
+    Serial.print(F("Error: expected 'enable' or 'disable' but got '"));
+    Serial.print(arg);
+    Serial.println("'");
+  }  
+}
+
 
 void topic_suffix_config(char * arg) {
   if(!configMemoryUnlocked(__LINE__)){
@@ -3977,6 +3916,7 @@ void safe_dtostrf(float value, signed char width, unsigned char precision, char 
 void backlightOn(void) {
   uint8_t backlight_behavior = eeprom_read_byte((uint8_t *) EEPROM_BACKLIGHT_STARTUP);
   if(backlight_behavior != BACKLIGHT_ALWAYS_OFF){
+    g_backlight_turned_on = true; // set global flag
     digitalWrite(A6, HIGH);
   }
 }
@@ -3984,6 +3924,7 @@ void backlightOn(void) {
 void backlightOff(void) {
   uint8_t backlight_behavior = eeprom_read_byte((uint8_t *) EEPROM_BACKLIGHT_STARTUP);
   if(backlight_behavior != BACKLIGHT_ALWAYS_ON){
+    g_backlight_turned_on = false; // clear global flag
     digitalWrite(A6, LOW);
   }
 }
@@ -4044,11 +3985,6 @@ void setLCD_P(const char * str PROGMEM){
 //}
 
 void repaintLCD(void){
-  static char last_painted[2][17] = {
-    "                ",
-    "                "
-  };
-  
   //dumpDisplayBuffer();      
   //  if(strlen((char *) &(g_lcd_buffer[0])) <= 16){
   //    lcd.setCursor(0,0);    
@@ -4087,6 +4023,10 @@ void setLCD(const char * str){
 }
 
 void updateLCD(const char * str, uint8_t pos_x, uint8_t pos_y, uint8_t num_chars){
+  updateLCD(str, pos_x, pos_y, num_chars, true);
+}
+
+void updateLCD(const char * str, uint8_t pos_x, uint8_t pos_y, uint8_t num_chars, boolean repaint){
   uint16_t len = strlen(str);
   char * ptr = 0;
   if((pos_y == 0) || (pos_y == 1)){
@@ -4105,16 +4045,30 @@ void updateLCD(const char * str, uint8_t pos_x, uint8_t pos_y, uint8_t num_chars
     }
   }
   
-  repaintLCD();
+  if(repaint){
+    repaintLCD();
+  }
 }
 
 void clearLCD(){
+  clearLCD(true);
+}
+
+void clearLCD(boolean repaint){
   memset((uint8_t *) &(g_lcd_buffer[0]), ' ', 16);
   memset((uint8_t *) &(g_lcd_buffer[1]), ' ', 16);
+  memset((uint8_t *) &(last_painted[0]), ' ', 16);
+  memset((uint8_t *) &(last_painted[1]), ' ', 16);
+        
   g_lcd_buffer[0][16] = '\0';
   g_lcd_buffer[1][16] = '\0';  
+  last_painted[0][16] = '\0';
+  last_painted[1][16] = '\0';      
+          
   lcd.clear();
-  repaintLCD();
+  if(repaint){
+    repaintLCD();
+  }
 }
 
 boolean index_of(char ch, char * str, uint16_t * index){
@@ -4294,6 +4248,10 @@ void leftpad_string(char * str, uint16_t target_length){
 }
 
 void updateLCD(float value, uint8_t pos_x, uint8_t pos_y, uint8_t field_width){
+  updateLCD(value, pos_x, pos_y, field_width, true);
+}
+
+void updateLCD(float value, uint8_t pos_x, uint8_t pos_y, uint8_t field_width, boolean repaint){
   static char tmp[64] = {0};
   static char asterisks_field[17] = {0};
   memset(tmp, 0, 64);
@@ -4323,7 +4281,7 @@ void updateLCD(float value, uint8_t pos_x, uint8_t pos_y, uint8_t field_width){
   //Serial.print(F("leftpad_string: "));
   //Serial.println(tmp);
       
-  updateLCD(tmp, pos_x, pos_y, field_width);  
+  updateLCD(tmp, pos_x, pos_y, field_width, repaint);  
 }
 
 void updateLCD(uint32_t ip, uint8_t line_number){
@@ -4417,7 +4375,7 @@ void displayRSSI(void){
   static ap_scan_result_t res = {0};    
   int8_t max_rssi = -256;
   boolean found_ssid = false;
-  uint8_t target_network_secMode = 0;
+  uint8_t target_network_secMode = WLAN_SEC_AUTO;  
   uint8_t network_security_mode = eeprom_read_byte((const uint8_t *) EEPROM_SECURITY_MODE);   
   uint8_t num_results_found = 0;  
   
@@ -4428,16 +4386,25 @@ void displayRSSI(void){
   Serial.println(F("Info: Beginning Network Scan..."));                
   SUCCESS_MESSAGE_DELAY();
   
-  boolean foundSSID = esp.scanForAccessPoint(ssid, &res, &num_results_found);
+  boolean foundSSID = false; 
+  uint8_t num_scan_attempts = 0;
+  do{
+    foundSSID = esp.scanForAccessPoint(ssid, &res, &num_results_found);
+    num_scan_attempts++;
+    if(!foundSSID){
+      delay(100);
+    }
+  } while(!foundSSID && (num_scan_attempts <= 3));
+  
   Serial.print(F("Info: Network Scan found "));
   Serial.print(num_results_found);
   Serial.println(F(" networks"));
   
-  Serial.print(F("Info: Found Access Point \""));
+  Serial.print(F("Info: Access Point \""));
   Serial.print(ssid);
   Serial.print(F("\", "));
   if(foundSSID){
-  
+    target_network_secMode = res.security;    
     Serial.print(F("RSSI = "));
     Serial.println(res.rssi);    
     int8_t rssi_dbm = res.rssi;
@@ -4465,6 +4432,7 @@ void displayRSSI(void){
   }
   else{
     Serial.println(F("Not Found.")); 
+    Serial.println(F("Info: Attempting to connect anyway."));
     updateLCD("NOT FOUND", 1);
     lcdFrownie(15, 1); // lower right corner
     ERROR_MESSAGE_DELAY();
@@ -4706,8 +4674,10 @@ void clearTempBuffers(void){
   memset(compensated_value_string, 0, 64);
   memset(raw_instant_value_string, 0, 64);  
   memset(raw_value_string, 0, 64);
-  memset(scratch, 0, 1024);
+  memset(scratch, 0, SCRATCH_BUFFER_SIZE);
+  scratch_idx = 0;
   memset(MQTT_TOPIC_STRING, 0, 128);
+  memset(response_body, 0, 256); 
 }
 
 boolean mqttResolve(void){
@@ -4842,7 +4812,7 @@ boolean publishHeartbeat(){
   static uint32_t post_counter = 0;  
   uint8_t sample = pgm_read_byte(&heartbeat_waveform[heartbeat_waveform_index++]);
   
-  snprintf(scratch, 1023, 
+  snprintf(scratch, SCRATCH_BUFFER_SIZE-1, 
   "{"
   "\"serial-number\":\"%s\","
   "\"converted-value\":%d,"
@@ -4872,7 +4842,8 @@ float toFahrenheit(float degC){
 
 boolean publishTemperature(){
   clearTempBuffers();
-  float temperature_moving_average = calculateAverage(&(sample_buffer[TEMPERATURE_SAMPLE_BUFFER][0]), sample_buffer_depth);
+  uint16_t num_samples = temperature_ready ? sample_buffer_depth : sample_buffer_idx;  
+  float temperature_moving_average = calculateAverage(&(sample_buffer[TEMPERATURE_SAMPLE_BUFFER][0]), num_samples);
   temperature_degc = temperature_moving_average;
   float raw_temperature = temperature_degc;
   float reported_temperature = temperature_degc - reported_temperature_offset_degC;
@@ -4895,7 +4866,7 @@ boolean publishTemperature(){
   replace_nan_with_null(raw_value_string);
   replace_nan_with_null(raw_instant_value_string);
   
-  snprintf(scratch, 1023,
+  snprintf(scratch, SCRATCH_BUFFER_SIZE-1,
     "{"
     "\"serial-number\":\"%s\","
     "\"converted-value\":%s,"
@@ -4928,7 +4899,8 @@ boolean publishTemperature(){
 
 boolean publishHumidity(){
   clearTempBuffers();
-  float humidity_moving_average = calculateAverage(&(sample_buffer[HUMIDITY_SAMPLE_BUFFER][0]), sample_buffer_depth);
+  uint16_t num_samples = humidity_ready ? sample_buffer_depth : sample_buffer_idx;  
+  float humidity_moving_average = calculateAverage(&(sample_buffer[HUMIDITY_SAMPLE_BUFFER][0]), num_samples);
   relative_humidity_percent = humidity_moving_average;
   float raw_humidity = constrain(relative_humidity_percent, 0.0f, 100.0f);
   float reported_humidity = constrain(relative_humidity_percent - reported_humidity_offset_percent, 0.0f, 100.0f);
@@ -4945,7 +4917,7 @@ boolean publishHumidity(){
   replace_nan_with_null(raw_value_string);
   replace_nan_with_null(raw_instant_value_string);
   
-  snprintf(scratch, 1023, 
+  snprintf(scratch, SCRATCH_BUFFER_SIZE-1, 
     "{"
     "\"serial-number\":\"%s\","    
     "\"converted-value\":%s,"
@@ -5007,12 +4979,13 @@ void collectTouch(void){
   }
 }
 
-void processTouchVerbose(boolean verbose_output){
+boolean processTouchVerbose(boolean verbose_output){
   const uint32_t touch_event_threshold = 85UL;  
   static boolean first_time = true;
   static unsigned long touch_start_millis = 0UL;
   long backlight_interval = 60000L; 
   static boolean backlight_is_on = false;
+  boolean ret = false;
  
   if(first_time){
     first_time = false;
@@ -5032,6 +5005,7 @@ void processTouchVerbose(boolean verbose_output){
       Serial.println(F("Info: Turning backlight on."));
     }
     touch_start_millis = current_millis;
+    ret = true;
   } 
   
   if((current_millis - touch_start_millis) >= backlight_interval) {        
@@ -5043,14 +5017,16 @@ void processTouchVerbose(boolean verbose_output){
       backlight_is_on = false;      
     }
   }  
+
+  return ret;
 }
 
-void processTouch(void){
-  processTouchVerbose(true);
+boolean processTouch(void){
+  return processTouchVerbose(true);
 }
 
-void processTouchQuietly(void){
-  processTouchVerbose(false);
+boolean processTouchQuietly(void){
+  return processTouchVerbose(false);
 }
 
 void advanceSampleBufferIndex(void){
@@ -5093,11 +5069,16 @@ float pressure_scale_factor(void){
   float ret = 1.0f;
   
   static boolean first_access = true;
-  static int16_t altitude_meters = 0.0f;
+  static int16_t user_altitude_meters = 0.0f;
   
   if(first_access){
     first_access = false;
-    altitude_meters = (int16_t) eeprom_read_word((uint16_t *) EEPROM_ALTITUDE_METERS);
+    user_altitude_meters = (int16_t) eeprom_read_word((uint16_t *) EEPROM_ALTITUDE_METERS);       
+  }
+
+  int16_t altitude_meters = user_altitude_meters;
+  if(!user_location_override && (gps_altitude != TinyGPS::GPS_INVALID_F_ALTITUDE)){
+    altitude_meters = (int16_t) gps_altitude;
   }
 
   if(altitude_meters != -1){
@@ -5137,8 +5118,9 @@ void co2_convert_to_ppm(float average, float * converted_value, float * temperat
 
 boolean publishCO2(){
   clearTempBuffers();
+  uint16_t num_samples = co2_ready ? sample_buffer_depth : sample_buffer_idx;  
   float converted_value = 0.0f, compensated_value = 0.0f;    
-  float co2_moving_average = calculateAverage(&(sample_buffer[CO2_SAMPLE_BUFFER][0]), sample_buffer_depth);
+  float co2_moving_average = calculateAverage(&(sample_buffer[CO2_SAMPLE_BUFFER][0]), num_samples);
   co2_convert_to_ppm(co2_moving_average, &converted_value, &compensated_value);
   co2_ppm = compensated_value;  
   //safe_dtostrf(co2_moving_average, -8, 5, raw_value_string, 16);
@@ -5156,7 +5138,7 @@ boolean publishCO2(){
   replace_nan_with_null(compensated_value_string);
   replace_nan_with_null(raw_instant_value_string);
   
-  snprintf(scratch, 1023, 
+  snprintf(scratch, SCRATCH_BUFFER_SIZE-1, 
     "{"
     "\"serial-number\":\"%s\","   
     "\"raw-instant-value\":%s,"    
@@ -5211,10 +5193,13 @@ void watchdogInitialize(void){
 void loop_wifi_mqtt_mode(void){
   static uint8_t num_mqtt_connect_retries = 0;
   static uint8_t num_mqtt_intervals_without_wifi = 0; 
+  static uint8_t publish_counter = 0;
   
   // mqtt publish timer intervals
   static unsigned long previous_mqtt_publish_millis = 0;
     
+  mqttReconnect(); // mqtt_client.loop gets called in here
+  
   if(current_millis - previous_mqtt_publish_millis >= reporting_interval){   
     suspendGpsProcessing();    
     previous_mqtt_publish_millis = current_millis;      
@@ -5225,18 +5210,20 @@ void loop_wifi_mqtt_mode(void){
       num_mqtt_intervals_without_wifi = 0;
       
       if(mqttReconnect()){         
-        updateLCD("TEMP ", 0, 0, 5);
-        updateLCD("RH ", 10, 0, 3);         
-        updateLCD("CO2 ", 0, 1, 4);        
+        updateLCD("TEMP ", 0, 0, 5, false);
+        updateLCD("RH ", 10, 0, 3, false);         
+        updateLCD("CO2 ", 0, 1, 4, false);        
                       
         //connected to MQTT server and connected to Wi-Fi network        
         num_mqtt_connect_retries = 0;   
-        if(!publishHeartbeat()){
-          Serial.println(F("Error: Failed to publish Heartbeat."));  
+        if((publish_counter % 10) == 0){ // only publish heartbeats every 10 reporting intervals          
+          if(!publishHeartbeat()){
+            Serial.println(F("Error: Failed to publish Heartbeat."));  
+          }
         }
         
         if(init_sht25_ok){
-          if(temperature_ready){
+          if(temperature_ready|| (sample_buffer_idx > 0)){
             if(!publishTemperature()){          
               Serial.println(F("Error: Failed to publish Temperature."));    
             }
@@ -5245,48 +5232,50 @@ void loop_wifi_mqtt_mode(void){
               if(temperature_units == 'F'){
                 reported_temperature = toFahrenheit(reported_temperature);
               }
-              updateLCD(reported_temperature, 5, 0, 3);             
+              updateLCD(reported_temperature, 5, 0, 3, false);             
             }
           }
           else{
-            updateLCD("---", 5, 0, 3);
+            updateLCD("---", 5, 0, 3, false);
           }        
         }
         else{
           // sht25 is not ok
-          updateLCD("XXX", 5, 0, 3);
+          updateLCD("XXX", 5, 0, 3, false);
         }
         
         if(init_sht25_ok){
-          if(humidity_ready){
+          if(humidity_ready || (sample_buffer_idx > 0)){
             if(!publishHumidity()){
               Serial.println(F("Error: Failed to publish Humidity."));  
             }
             else{
               float reported_relative_humidity_percent = relative_humidity_percent - reported_humidity_offset_percent;
-              updateLCD(reported_relative_humidity_percent, 13, 0, 3);  
+              updateLCD(reported_relative_humidity_percent, 13, 0, 3, false);  
             }
           }
           else{
-            updateLCD("---", 13, 0, 3);
+            updateLCD("---", 13, 0, 3, false);
           }
         }
         else{
-          updateLCD("XXX", 13, 0, 3);
+          updateLCD("XXX", 13, 0, 3, false);
         }
         
         
-        if(co2_ready){
+        if(co2_ready || (sample_buffer_idx > 0)){
           if(!publishCO2()){
-            Serial.println(F("Error: Failed to publish CO2."));                    
+            Serial.println(F("Error: Failed to publish CO2."));
           }
           else{
-            updateLCD(co2_ppm, 5, 1, 5);  
+            updateLCD(co2_ppm, 5, 1, 5, false);  
           }
         }
         else{
-          updateLCD("---", 5, 1, 5); 
-        }            
+          updateLCD("---", 5, 1, 5, false); 
+        }  
+
+        repaintLCD();
       }
       else{
         // not connected to MQTT server
@@ -5332,6 +5321,8 @@ void loop_wifi_mqtt_mode(void){
       
       restartWifi();
     }
+
+    publish_counter++;
   }    
 }
 
@@ -5339,8 +5330,10 @@ void loop_offline_mode(void){
   
   // write record timer intervals
   static unsigned long previous_write_record_millis = 0;
+  static boolean first = true;
 
-  if(current_millis - previous_write_record_millis >= reporting_interval){   
+  if(first || (current_millis - previous_write_record_millis >= reporting_interval)){ 
+    first = false;
     suspendGpsProcessing();   
     previous_write_record_millis = current_millis;
     printCsvDataLine();
@@ -5362,9 +5355,10 @@ void printCsvDataLine(){
   static boolean first = true;
   char * dataString = &(scratch[0]);  
   clearTempBuffers();
+  static uint32_t call_counter = 0;
   
   uint16_t len = 0;
-  uint16_t dataStringRemaining = 511;
+  uint16_t dataStringRemaining = SCRATCH_BUFFER_SIZE-1;
   
   if(first){   
     first = false;      
@@ -5378,8 +5372,10 @@ void printCsvDataLine(){
   Serial.print(F(","));
   appendToString("," , dataString, &dataStringRemaining);
   
-  if(temperature_ready){
-    temperature_degc = calculateAverage(&(sample_buffer[TEMPERATURE_SAMPLE_BUFFER][0]), sample_buffer_depth);
+  uint16_t num_samples = temperature_ready ? sample_buffer_depth : sample_buffer_idx;  
+
+  if(init_sht25_ok && (temperature_ready || (sample_buffer_idx > 0))){
+    temperature_degc = calculateAverage(&(sample_buffer[TEMPERATURE_SAMPLE_BUFFER][0]), num_samples);
     float reported_temperature = temperature_degc - reported_temperature_offset_degC;
     if(temperature_units == 'F'){
       reported_temperature = toFahrenheit(reported_temperature);
@@ -5395,8 +5391,9 @@ void printCsvDataLine(){
   Serial.print(F(","));
   appendToString("," , dataString, &dataStringRemaining);
   
-  if(humidity_ready){
-    relative_humidity_percent = calculateAverage(&(sample_buffer[HUMIDITY_SAMPLE_BUFFER][0]), sample_buffer_depth);
+  num_samples = humidity_ready ? sample_buffer_depth : sample_buffer_idx;
+  if(init_sht25_ok && (humidity_ready || (sample_buffer_idx > 0))){
+    relative_humidity_percent = calculateAverage(&(sample_buffer[HUMIDITY_SAMPLE_BUFFER][0]), num_samples);
     float reported_relative_humidity = relative_humidity_percent - reported_humidity_offset_percent;        
     Serial.print(reported_relative_humidity, 2);
     appendToString(reported_relative_humidity, 2, dataString, &dataStringRemaining);
@@ -5410,9 +5407,10 @@ void printCsvDataLine(){
   appendToString("," , dataString, &dataStringRemaining);
   
   float co2_moving_average = 0.0f;
-  if(co2_ready){
+  num_samples = co2_ready ? sample_buffer_depth : sample_buffer_idx;
+  if(co2_ready || (sample_buffer_idx > 0)){
     float converted_value = 0.0f, compensated_value = 0.0f;    
-    co2_moving_average = calculateAverage(&(sample_buffer[CO2_SAMPLE_BUFFER][0]), sample_buffer_depth);
+    co2_moving_average = calculateAverage(&(sample_buffer[CO2_SAMPLE_BUFFER][0]), num_samples);
     co2_convert_to_ppm(co2_moving_average, &converted_value, &compensated_value);
     co2_ppm = compensated_value;        
     
@@ -5424,69 +5422,70 @@ void printCsvDataLine(){
     appendToString("---", dataString, &dataStringRemaining);
   }
 
-  Serial.print(F(","));
-  appendToString("," , dataString, &dataStringRemaining);
-
-  if(gps_latitude != TinyGPS::GPS_INVALID_F_ANGLE){
-    Serial.print(gps_latitude, 6);
-    appendToString(gps_latitude, 6, dataString, &dataStringRemaining);
-  }
-  else{
-    Serial.print(F("---"));
-    appendToString("---", dataString, &dataStringRemaining);
-  }
+  Serial.print(gps_csv_string);
+  appendToString(gps_csv_string, dataString, &dataStringRemaining);
   
-  Serial.print(F(","));
-  appendToString("," , dataString, &dataStringRemaining);
-
-  if(gps_longitude != TinyGPS::GPS_INVALID_F_ANGLE){
-    Serial.print(gps_longitude, 6);
-    appendToString(gps_longitude, 6, dataString, &dataStringRemaining);
-  }
-  else{
-    Serial.print(F("---"));
-    appendToString("---", dataString, &dataStringRemaining);
-  }  
-
-  Serial.print(F(","));
-  appendToString("," , dataString, &dataStringRemaining);
-
-  if(gps_altitude != TinyGPS::GPS_INVALID_F_ALTITUDE){
-    Serial.print(gps_altitude, 6);
-    appendToString(gps_altitude, 2, dataString, &dataStringRemaining);
-  }
-  else{
-    Serial.print(F("---"));
-    appendToString("---", dataString, &dataStringRemaining);
-  }
-
-
   Serial.println();
   appendToString("\n", dataString, &dataStringRemaining);  
         
-  if((mode == SUBMODE_OFFLINE) && init_sdcard_ok){
-    char filename[16] = {0};
-    getNowFilename(filename, 15);     
-    File dataFile = SD.open(filename, FILE_WRITE);
-    if (dataFile) {
-      dataFile.print(dataString);
-      dataFile.close();
+  if((call_counter % 10) == 0){ // once every 10 reports    
+    clearLCD(false);
+    if((mode == SUBMODE_OFFLINE) && init_sdcard_ok){
+      char filename[16] = {0};
+      getNowFilename(filename, 15);     
+      File dataFile = SD.open(filename, FILE_WRITE);
+      if (dataFile) {
+        dataFile.print(dataString);
+        dataFile.close();
+        setLCD_P(PSTR("  LOGGING DATA  "
+                      "   TO SD CARD   "));   
+      }
+      else {
+        Serial.print("Error: Failed to open SD card file named \"");
+        Serial.print(filename);
+        Serial.println(F("\""));
+        setLCD_P(PSTR("  SD CARD FILE  "
+                      "  OPEN FAILED   "));
+        lcdFrownie(15, 1);      
+      }
+    }
+    else if((mode == SUBMODE_OFFLINE) && !init_sdcard_ok){
       setLCD_P(PSTR("  LOGGING DATA  "
-                    "   TO SD CARD   "));   
-    }
-    else {
-      Serial.print("Error: Failed to open SD card file named \"");
-      Serial.print(filename);
-      Serial.println(F("\""));
-      setLCD_P(PSTR("  SD CARD FILE  "
-                    "  OPEN FAILED   "));
-      lcdFrownie(15, 1);      
+                    "  TO USB-SERIAL "));
     }
   }
-  else if((mode == SUBMODE_OFFLINE) && !init_sdcard_ok){
-    setLCD_P(PSTR("  LOGGING DATA  "
-                  "  TO USB-SERIAL "));
+  else { // otherwise display the data
+    clearLCD(false);
+    updateLCD("TEMP ", 0, 0, 5, false);
+    updateLCD("RH ", 10, 0, 3, false);         
+    updateLCD("CO2 ", 0, 1, 4, false);
+                      
+    if(init_sht25_ok){
+      float reported_temperature = temperature_degc - reported_temperature_offset_degC;
+      if(temperature_units == 'F'){
+        reported_temperature = toFahrenheit(reported_temperature);
+      }
+      updateLCD(reported_temperature, 5, 0, 3, false);             
+    }
+    else{
+      // sht25 is not ok
+      updateLCD("XXX", 5, 0, 3, false);
+    }
+    
+    if(init_sht25_ok){
+      float reported_relative_humidity_percent = relative_humidity_percent - reported_humidity_offset_percent;
+      updateLCD(reported_relative_humidity_percent, 13, 0, 3, false);        
+    }
+    else{
+      updateLCD("XXX", 13, 0, 3, false);
+    }
+    
+    updateLCD(co2_ppm, 5, 1, 5, false);  
+
+    repaintLCD();    
   }
+  
+  call_counter++;
 }
 
 boolean mode_requires_wifi(uint8_t opmode){
@@ -5625,8 +5624,8 @@ void downloadFile(char * hostname, uint16_t port, char * filename, void (*respon
   */ 
   esp.connect(hostname, port);
   if (esp.connected()) {   
-    memset(scratch, 0, 1024);
-    snprintf(scratch, 1023, "GET /%s HTTP/1.1\r\nHost: %s\r\n\r\n\r\n", filename, hostname);        
+    memset(scratch, 0, SCRATCH_BUFFER_SIZE);
+    snprintf(scratch, SCRATCH_BUFFER_SIZE-1, "GET /%s HTTP/1.1\r\nHost: %s\r\n\r\n\r\n", filename, hostname);        
     esp.print(scratch);
     //Serial.print(scratch);    
   } else {
@@ -6019,7 +6018,7 @@ boolean mirrored_config_restore_and_validate(void){
       Serial.println(F("Info: Successfully restored to last valid configuration.")); 
     }
     else{
-      Serial.println(F("Info: Restored last valid configuration, but it's still not valid."));
+      Serial.println(F("Info: Restored last valid configuration, but it's still not valid. Possibly catastrophic."));
     }  
   }
   else{
@@ -6120,16 +6119,51 @@ void rtcClearOscillatorStopFlag(void){
 
 /****** GPS SUPPORT FUNCTIONS ******/
 void updateGpsStrings(void){
-  const char * gps_lat_lng_field_mqtt_template = ",\"latitude\":%10.6f,\"longitude\":%11.6f";
-  const char * gps_lat_lng_alt_field_mqtt_template  = ",\"latitude\":%10.6f,\"longitude\":%11.6f,\"altitude\":%8.2f"; 
-  const char * gps_lat_lng_field_csv_template = ",%10.6f,%11.6f,---";
-  const char * gps_lat_lng_alt_field_csv_template  = ",%10.6f,%11.6f,%8.2f";   
+  const char * gps_lat_lng_field_mqtt_template = ",\"__location\":{\"lat\":%.6f,\"lon\":%.6f}"; 
+  const char * gps_lat_lng_alt_field_mqtt_template  = ",\"__location\":{\"lat\":%.6f,\"lon\":%.6f,\"alt\":%.2f}"; 
+  const char * gps_lat_lng_field_csv_template = ",%.6f,%.6f,---";
+  const char * gps_lat_lng_alt_field_csv_template  = ",%.6f,%.6f,%.2f";   
+
+  static boolean first = true;
+  if(first){
+    first = false;
+    float tmp = eeprom_read_float((float *) EEPROM_USER_LATITUDE_DEG);
+    // Serial.println(tmp,6);    
+    if(!isnan(tmp) && (tmp >= -90.0f) && (tmp <= 90.0f)){
+      user_latitude = tmp;
+    }
+    
+    tmp = eeprom_read_float((float *) EEPROM_USER_LONGITUDE_DEG);
+    // Serial.println(tmp,6);
+    if(!isnan(tmp) && (tmp >= -180.0f) && (tmp <= 180.0f)){
+      user_longitude = tmp;
+    }
+
+    int16_t l_tmp = (int16_t) eeprom_read_word((uint16_t *) EEPROM_ALTITUDE_METERS);
+    // Serial.println(l_tmp);
+    if(tmp != -1){
+      user_altitude = 1.0f * l_tmp;
+    }
+
+    // Serial.println(user_latitude, 6);
+    // Serial.println(user_longitude, 6);
+    // Serial.println(user_altitude, 2);
+  }
   
   memset(gps_mqtt_string, 0, GPS_MQTT_STRING_LENGTH);
   memset(gps_csv_string, 0, GPS_CSV_STRING_LENGTH);
-  strcpy_P(gps_csv_string, PSTR(",---,---,---"));
   
-  if((gps_latitude != TinyGPS::GPS_INVALID_F_ANGLE) && (gps_longitude != TinyGPS::GPS_INVALID_F_ANGLE)){
+  if(user_location_override && (user_latitude != TinyGPS::GPS_INVALID_F_ANGLE) && (user_longitude != TinyGPS::GPS_INVALID_F_ANGLE)){    
+    if(user_altitude != -1.0f){
+      snprintf(gps_mqtt_string, GPS_MQTT_STRING_LENGTH-1, gps_lat_lng_alt_field_mqtt_template, user_latitude, user_longitude, user_altitude);
+      snprintf(gps_csv_string, GPS_CSV_STRING_LENGTH-1, gps_lat_lng_alt_field_csv_template, user_latitude, user_longitude, user_altitude);
+    }
+    else{      
+      snprintf(gps_mqtt_string, GPS_MQTT_STRING_LENGTH-1, gps_lat_lng_field_mqtt_template, user_latitude, user_longitude);
+      snprintf(gps_csv_string, GPS_CSV_STRING_LENGTH-1, gps_lat_lng_field_csv_template, user_latitude, user_longitude);
+    }       
+  }  
+  else if((gps_latitude != TinyGPS::GPS_INVALID_F_ANGLE) && (gps_longitude != TinyGPS::GPS_INVALID_F_ANGLE)){
     if(gps_altitude != TinyGPS::GPS_INVALID_F_ALTITUDE){
       snprintf(gps_mqtt_string, GPS_MQTT_STRING_LENGTH-1, gps_lat_lng_alt_field_mqtt_template, gps_latitude, gps_longitude, gps_altitude);
       snprintf(gps_csv_string, GPS_CSV_STRING_LENGTH-1, gps_lat_lng_alt_field_csv_template, gps_latitude, gps_longitude, gps_altitude);
@@ -6138,6 +6172,9 @@ void updateGpsStrings(void){
       snprintf(gps_mqtt_string, GPS_MQTT_STRING_LENGTH-1, gps_lat_lng_field_mqtt_template, gps_latitude, gps_longitude);
       snprintf(gps_csv_string, GPS_CSV_STRING_LENGTH-1, gps_lat_lng_field_csv_template, gps_latitude, gps_longitude);
     }    
+  }
+  else{    
+    strcpy_P(gps_csv_string, PSTR(",---,---,---"));
   }
 }
 
@@ -6432,3 +6469,418 @@ void dump_config(uint8_t * buf){
   }
 }
 */
+
+void doSoftApModeConfigBehavior(void){  
+  // if the user has opted out of soft ap mode, then don't do anything, just return
+  if(eeprom_read_byte((const uint8_t *) EEPROM_DISABLE_SOFTAP) == 1){
+    return;
+  }
+  
+  clearTempBuffers();
+  
+  randomSeed(micros());
+  char random_password[16] = {0}; 
+  strcpy(random_password, ""); // could use a fixed prefix by initializing it here
+  uint8_t fixed_password_length = strlen(random_password);
+  const uint8_t random_password_length = 8;
+    
+  static const char whitelist[] PROGMEM = {
+    '2',  '3',  '4',  '5',  '6',  '7',  '8',  '9',  
+//    'A',  'B',  'C',  'D',  'E',  'F',  'G',  'H',  
+//    'J',  'K',  'L',  'M',  'N',  'P',  'R',  'S',
+//    'T',  'U',  'V',  'W',  'X',  'Y',  'Z',  'a',  
+    'a', 'b',  'c',  'd',  'e',  'f',  'g',  'h',  'i',  
+//    'j',  'k',  'm',  'n',  'o',  'p',  'q',  'r',  
+    'j',  'k',  'm',  'n',  'o',  'p',  'r',  
+    's',  't',  'u',  'v',  'w',  'x',  'y',  'z'
+  };
+  uint8_t _mac_address[6] = {0};
+  eeprom_read_block((void *)_mac_address, (const void *) EEPROM_MAC_ADDRESS, 6);
+  char egg_ssid[16] = {0};
+  sprintf(egg_ssid, "egg-%02x%02x%02x", _mac_address[3], _mac_address[4], _mac_address[5]);  
+
+  uint8_t ii = fixed_password_length;
+  while(ii < random_password_length){
+    uint8_t idx = random(0, 'z' - '0' + 1);
+    char c = (char) ('0' + idx); 
+    
+    // if it's in the white list allow it
+    boolean in_whitelist = false;
+    for(uint8_t jj = 0; jj < sizeof(whitelist); jj++){
+      char wl_char = pgm_read_byte(&(whitelist[jj]));      
+      if(wl_char == c){
+        in_whitelist = true;
+        break;
+      }
+    }
+
+    if(in_whitelist){
+      random_password[ii++] = c;     
+      random_password[ii] = NULL;     
+    }
+  }
+
+  clearLCD();
+  updateLCD(egg_ssid, 0);   
+  updateLCD(&random_password[fixed_password_length], 1);
+
+  const uint32_t default_seconds_remaining_in_softap_mode = 5UL * 60UL; // stay in softap for 5 minutes max  
+  uint32_t seconds_remaining_in_softap_mode = default_seconds_remaining_in_softap_mode;
+  
+  boolean explicit_exit_softap = false;
+  const uint16_t softap_http_port = 80;
+  char ssid[33] = {0};
+  char pwd[33] = {0};
+  
+  if(esp.setNetworkMode(3)){ // means softAP mode
+    Serial.println(F("Info: Enabled Soft AP"));    
+    if(esp.configureSoftAP(egg_ssid, random_password, 5, 3)){ // channel = 5, sec = WPA      
+      // open a port and listen for config data messages, for up to two minutes
+      if(esp.listen(softap_http_port)){
+        Serial.print(F("Info: Listening for connections on port "));
+        Serial.print(softap_http_port);
+        Serial.println(F("..."));
+        Serial.print(F("Info: SoftAP password is \""));
+        Serial.print(random_password);        
+        Serial.println(F("\""));
+        
+        unsigned long previousMillis = 0;
+        const long interval = 1000;                
+        boolean got_opening_brace = false;        
+        boolean got_closing_brace = false;
+                
+        while((seconds_remaining_in_softap_mode != 0) && (!explicit_exit_softap)){
+          unsigned long currentMillis = millis();
+
+          if (currentMillis - previousMillis >= interval) {                        
+            previousMillis = currentMillis;
+            if(seconds_remaining_in_softap_mode != 0){
+              seconds_remaining_in_softap_mode--;
+              Serial.print(".");       
+              updateCornerDot();                    
+              if((seconds_remaining_in_softap_mode % 60) == 0){
+                Serial.println();
+              }
+            }                        
+            petWatchdog();            
+          }
+
+          // check backlight touch
+          if(currentMillis - previous_touch_sampling_millis >= touch_sampling_interval){              
+            previous_touch_sampling_millis = currentMillis;    
+            collectTouch();    
+            processTouchQuietly();                            
+          }      
+
+          // check to determine if we have a GPS
+          while(!gps_installed && gpsSerial.available()){
+            char c = gpsSerial.read();
+            if(c == '$'){
+              gps_installed = true;
+            }
+          }
+          
+          // pay attention to incoming traffic          
+          while(esp.available()){
+            char c = esp.read();
+            if(got_opening_brace){
+              if(c == '}'){
+                got_closing_brace = true;    
+                scratch[scratch_idx++] = c;
+                break;
+              }
+              else{
+                if(scratch_idx < SCRATCH_BUFFER_SIZE - 1){
+                  scratch[scratch_idx++] = c;                  
+                }
+                else{
+                  Serial.println("Warning: scratch buffer out of memory");
+                }
+              }
+            }
+            else if(c == '{'){              
+              got_opening_brace = true;
+              scratch[scratch_idx++] = c;
+            }            
+          }                     
+
+          if(got_closing_brace){
+            // Serial.println("Message Body: ");
+            // Serial.println(scratch);  
+            
+            // send back an HTTP response 
+            // Then send a few headers to identify the type of data returned and that
+            // the connection will not be held open.                            
+            char response_template[] PROGMEM = "HTTP/1.1 200 OK\r\n"         
+              "Content-Type: application/json; charset=utf-8\r\n"
+              "Connection: close\r\n"
+              "Server: air quality egg\r\n"
+              "Content-Length: %d\r\n"
+              "Access-Control-Allow-Origin: *\r\n"
+              "\r\n"
+              "%s";
+            
+            const char response_body_template[] PROGMEM = 
+              "{"
+               "\"sn\":\"%s\","
+               "\"model\":\"%s\","
+               "\"fw_ver\":\"%d.%d.%d\","
+               "\"has_gps\":%s,"
+               "\"use_gps\":%s,"
+               "\"temp_unit\":\"%s\","
+               "\"ssid\":\"%s\","
+               "\"wifi_conn\":%s,"
+               "\"attempts\":%d,"
+               "\"opmode\":\"%s\","
+               "\"has_sd\":%s,"
+               "\"lat\":%s,"
+               "\"lng\":%s,"
+               "\"alt\":%s"
+              "}";            
+                                       
+            char serial_number[32] = {0};
+            char ssid[33] = {0};
+            char userLat[16] = {0};
+            char userLng[16] = {0};
+            char userAlt[16] = {0};  
+            char operational_mode[16] = {0};  
+            
+            if(parseConfigurationMessageBody(scratch)){
+              explicit_exit_softap = true;              
+            }
+            
+            eeprom_read_block(serial_number, (const void *) EEPROM_MQTT_CLIENT_ID, 31);
+            eeprom_read_block(ssid, (const void *) EEPROM_SSID, 32);
+
+            int16_t l_alt = (int16_t) eeprom_read_word((uint16_t *) EEPROM_ALTITUDE_METERS);
+            float f_alt = 0.0f / 0.0f; // should result in nan (on purpose)
+            if(l_alt != -1){
+              f_alt = 1.0f * l_alt;
+            }
+
+            uint8_t m = eeprom_read_byte((const uint8_t *) EEPROM_OPERATIONAL_MODE);
+            if(m == SUBMODE_NORMAL){
+              strcpy(operational_mode, "normal");
+            }
+            else if(m == SUBMODE_OFFLINE){
+              strcpy(operational_mode, "offline");
+            }
+            else{
+              strcpy(operational_mode, "unknown");
+            }
+            
+            floatToJsString(f_alt, userAlt, 2);
+            floatToJsString(eeprom_read_float((float *) EEPROM_USER_LATITUDE_DEG), userLat, 6);
+            floatToJsString(eeprom_read_float((float *) EEPROM_USER_LONGITUDE_DEG), userLng, 6);
+            
+            const char model_type[] = "D";
+            const char true_string[] = "true";
+            const char false_string[] = "false";
+            
+            char * hasGPS = gps_installed ? (char *) true_string : (char *) false_string;
+            char * useGPS = user_location_override ? (char *) false_string : (char *) true_string;
+            char * wifiConn = wifi_can_connect ? (char *) true_string : (char *) false_string;
+            char * hasSD = init_sdcard_ok ? (char *) true_string : (char *) false_string;
+                        
+            char tempUnit[2] = {0};
+            tempUnit[0] = eeprom_read_byte((const uint8_t *) EEPROM_TEMPERATURE_UNITS);          
+
+            clearTempBuffers();   
+            
+            sprintf(response_body, response_body_template, 
+              serial_number,
+              model_type,
+              AQEV2FW_MAJOR_VERSION,
+              AQEV2FW_MINOR_VERSION,
+              AQEV2FW_PATCH_VERSION,
+              hasGPS,
+              useGPS,
+              tempUnit,
+              ssid,
+              wifiConn,
+              wifi_connect_attempts,
+              operational_mode,
+              hasSD,
+              userLat,
+              userLng,
+              userAlt
+              );             
+                                           
+            sprintf(scratch, response_template, strlen(response_body), response_body);            
+            
+            // Serial.print("Responding With: ");
+            // Serial.println(scratch);  
+            esp.print(scratch);
+            seconds_remaining_in_softap_mode = default_seconds_remaining_in_softap_mode;
+            
+            // and wait 100ms to make sure it gets back to the caller
+            delay(100); 
+            esp.stop();
+            
+            clearTempBuffers();                 
+            // if the parse failed we're back to waiting for a message body
+            got_closing_brace = false;
+            got_opening_brace = false;       
+            
+//            clearLCD();
+//            updateLCD(egg_ssid, 0);   
+//            updateLCD(&random_password[fixed_password_length], 1);  
+//
+//            clearTempBuffers();                               
+          }          
+        }        
+      }
+      else{
+        Serial.print(F("Error: Failed to start TCP server on port "));
+        Serial.println(softap_http_port);
+      }    
+    }
+    else{
+      Serial.println(F("Error: Failed to configure Soft AP"));
+    }
+  }
+  else{
+    Serial.println(F("Error: Failed to start Soft AP Mode"));  
+  }  
+
+  Serial.println(F("Info: Exiting SoftAP Mode"));
+}
+
+void floatToJsString(float f, char * target, uint8_t digits_after_decimal_point){
+  // only allow up 0 - 9 digits after decimal point
+  if(digits_after_decimal_point > 9){
+    digits_after_decimal_point = 9;
+  }
+
+  if(isnan(f)){
+    strcpy(target, "null");
+  }
+  else{
+    char format_string[] = "%.0f";                  // initialize digits after decimal point to 0
+    format_string[2] += digits_after_decimal_point; // update the digits after decimal point
+    sprintf(target, format_string, f);     
+  }
+}
+
+boolean parseConfigurationMessageBody(char * body){
+  jsmn_init(&parser);
+  
+  boolean found_ssid = false;
+  boolean found_pwd = false;
+  boolean handled_ssid_pwd = false;
+  boolean found_exit = false;
+
+  int16_t r = jsmn_parse(&parser, body, strlen(body), json_tokens, sizeof(json_tokens)/sizeof(json_tokens[0]));
+  if(r > 0) {
+    Serial.print(F("Info: Found "));
+    Serial.print(r);
+    Serial.println(F(" JSON tokens"));
+  }
+  else{
+    Serial.print(F("Info: JSON parse failed for body \""));
+    Serial.print(body);
+    Serial.print(F("\" response code "));
+    Serial.println(r);
+  }
+  char key[33] = {0};
+  char value[33] = {0};
+  char ssid[33] = {0};
+  char pwd[33] = {0};
+  
+  for(uint8_t ii = 1; ii < r; ii+=2){    
+    memset(key, 0, 33);
+    memset(value, 0, 33);
+    uint16_t keylen = json_tokens[ii].end - json_tokens[ii].start;
+    uint16_t valuelen = json_tokens[ii+1].end - json_tokens[ii+1].start;
+
+    if(keylen <= 32){
+      strncpy(key, body + json_tokens[ii].start, keylen);      
+    }
+
+    if(valuelen <= 32){
+      strncpy(value, body + json_tokens[ii+1].start, valuelen);
+    }
+
+     Serial.print(F("Info: JSON token: "));
+     Serial.print(key);
+     Serial.print(" => ");
+     Serial.print(value);
+     Serial.println();   
+
+    // handlers for valid JSON keys
+    if(strcmp(key, "ssid") == 0){
+      found_ssid = true;
+      strcpy(ssid, value);
+    }
+    else if(strcmp(key, "pwd") == 0){
+      found_pwd = true;
+      strcpy(pwd, value);
+    }
+    else if((strcmp(key, "exit") == 0) && (strcmp(value, "true") == 0)){
+      found_exit = true;
+    }
+    else if(strcmp(key, "use_gps") == 0){
+      if(strcmp(value, "true") == 0){
+        set_user_location_enable("disable");
+      }
+      else if(strcmp(value, "false") == 0){
+        set_user_location_enable("enable");
+      }
+    }
+    else if(strcmp(key, "lat") == 0){
+      set_user_latitude(value);
+    }
+    else if(strcmp(key, "lng") == 0){
+      set_user_longitude(value);
+    }
+    else if(strcmp(key, "alt") == 0){
+      altitude_command(value);
+    }
+    else if(strcmp(key, "temp_unit") == 0){
+      set_temperature_units(value);
+    }
+    else if(strcmp(key, "opmode") == 0){
+      set_operational_mode(value);
+    }
+    else{
+      Serial.print(F("Warn: posted key \""));
+      Serial.print(key);
+      Serial.print(F("\" is unrecognized and will be ignored."));
+      Serial.println();
+    }
+
+    if(!handled_ssid_pwd && found_ssid && found_pwd){
+      Serial.print(F("Info: Trying to connect to target network"));
+      wifi_connect_attempts++;
+
+      set_ssid(ssid);
+      set_network_password(pwd);     
+      set_network_security_mode("auto");      
+      
+      if(esp.connectToNetwork((char *) ssid, (char *) pwd, 30000)){              
+        Serial.print(F("Info: Successfully connected to Network \""));
+        Serial.print(ssid);
+        Serial.print(F("\""));
+        Serial.println();
+        wifi_can_connect = true;      
+      }
+      else{
+        Serial.print(F("Info: Unable to connect to Network \""));
+        Serial.print(ssid);
+        Serial.print(F("\""));
+        Serial.println();        
+        wifi_can_connect = false;
+      }
+      handled_ssid_pwd = true;
+    }
+  }
+
+  // commit changes, because it's annoying to lose settings because of an Egg reset
+  if(!mirrored_config_matches_eeprom_config()){   
+    if(checkConfigIntegrity()){              
+      commitConfigToMirroredConfig();
+    }
+  }
+
+  return found_exit;
+}

--- a/AQEV2FW_CO2_ESP.ino
+++ b/AQEV2FW_CO2_ESP.ino
@@ -505,7 +505,6 @@ void setup() {
 
   // initialize hardware
   initializeHardware();
-  backlightOff();
 
   //  uint8_t tmp[EEPROM_CONFIG_MEMORY_SIZE] = {0};
   //  get_eeprom_config(tmp);
@@ -629,6 +628,7 @@ void setup() {
       }
     }
     Serial.println();
+    backlightOn();
 
     if(soft_ap_config_activated){
       configInject("aqe\r");
@@ -719,11 +719,11 @@ void setup() {
       prompt();
       for (;;) {
         current_millis = millis();
-        if(current_millis - previous_touch_sampling_millis >= touch_sampling_interval){
-          previous_touch_sampling_millis = current_millis;
-          collectTouch();
-          processTouchQuietly();
-        }
+//        if(current_millis - previous_touch_sampling_millis >= touch_sampling_interval){
+//          previous_touch_sampling_millis = current_millis;
+//          collectTouch();
+//          processTouchQuietly();
+//        }
 
         // check to determine if we have a GPS
         while(!gps_installed && gpsSerial.available()){
@@ -886,6 +886,7 @@ void setup() {
   }
 
   resumeGpsProcessing();
+  backlightOff();
 }
 
 void loop() {
@@ -6867,7 +6868,7 @@ boolean parseConfigurationMessageBody(char * body){
       set_network_password(pwd);
       set_network_security_mode("auto");
 
-      if(esp.connectToNetwork((char *) ssid, (char *) pwd, 30000)){
+      if(esp.connectToNetwork((char *) ssid, (char *) pwd, 45000)){
         Serial.print(F("Info: Successfully connected to Network \""));
         Serial.print(ssid);
         Serial.print(F("\""));

--- a/AQEV2FW_CO2_ESP.ino
+++ b/AQEV2FW_CO2_ESP.ino
@@ -1233,7 +1233,11 @@ void initializeNewConfigSettings(void){
     }
 
     configInject("softap enable\r");
-    configInject("sampling 5, 60, 60\r");
+
+    // only apply the sampling update to CO2 eggs if their sampling interval is currently 5 seconds
+    if(eeprom_read_word((uint16_t * ) EEPROM_SAMPLING_INTERVAL) == 5){       
+      configInject("sampling 5, 60, 60\r");
+    }
     eeprom_write_byte((uint8_t *) EEPROM_2_2_0_SAMPLING_UPD, 1);
 
     // check if ntpsrv is pool.ntp.org, and if so, switch it to 0.airqualityegg.pool.ntp.org

--- a/AQEV2FW_CO2_ESP.ino
+++ b/AQEV2FW_CO2_ESP.ino
@@ -26,7 +26,7 @@
 
 // the start address of the second to last 4k page, where config is backed up off MCU
 // the last page is reserved for use by the bootloader
-#define SECOND_TO_LAST_4K_PAGE_ADDRESS      0x7E000     
+#define SECOND_TO_LAST_4K_PAGE_ADDRESS      0x7E000
 
 int esp8266_enable_pin = 23; // Arduino digital the pin that is used to reset/enable the ESP8266 module
 
@@ -42,7 +42,7 @@ LiquidCrystal lcd(A3, A2, 4, 5, 6, 8);
 char g_lcd_buffer[2][17] = {0}; // 2 rows of 16 characters each, with space for NULL terminator
 char last_painted[2][17] = {"                ","                "};
 
-byte mqtt_server_ip[4] = { 0 };    
+byte mqtt_server_ip[4] = { 0 };
 PubSubClient mqtt_client;
 char mqtt_client_id[32] = {0};
 
@@ -62,7 +62,7 @@ boolean gps_disabled = false;
 #define GPS_MQTT_STRING_LENGTH (128)
 #define GPS_CSV_STRING_LENGTH (64)
 char gps_mqtt_string[GPS_MQTT_STRING_LENGTH] = {0};
-char gps_csv_string[GPS_CSV_STRING_LENGTH] = {0}; 
+char gps_csv_string[GPS_CSV_STRING_LENGTH] = {0};
 
 uint32_t update_server_ip32 = 0;
 char update_server_name[32] = {0};
@@ -129,7 +129,7 @@ boolean init_sdcard_ok = false;
 boolean init_rtc_ok = false;
 
 typedef struct{
-  float temperature_degC;     // starting at this temperature 
+  float temperature_degC;     // starting at this temperature
   float slope_volts_per_degC; // use a line with this slope
   float intercept_volts;      // and this intercept
                               // to calculate the baseline voltage
@@ -162,7 +162,7 @@ uint8_t mode = MODE_OPERATIONAL;
 
 #define EEPROM_MAC_ADDRESS    (E2END + 1 - 6)    // MAC address, i.e. the last 6-bytes of EEPROM
 // more parameters follow, address relative to each other so they don't overlap
-#define EEPROM_CONNECT_METHOD     (EEPROM_MAC_ADDRESS - 1)        // connection method encoded as a single byte value 
+#define EEPROM_CONNECT_METHOD     (EEPROM_MAC_ADDRESS - 1)        // connection method encoded as a single byte value
 #define EEPROM_SSID               (EEPROM_CONNECT_METHOD - 32)    // ssid string, up to 32 characters (one of which is a null terminator)
 #define EEPROM_NETWORK_PWD        (EEPROM_SSID - 32)              // network password, up to 32 characters (one of which is a null terminator)
 #define EEPROM_SECURITY_MODE      (EEPROM_NETWORK_PWD - 1)        // security mode encoded as a single byte value
@@ -172,11 +172,11 @@ uint8_t mode = MODE_OPERATIONAL;
 #define EEPROM_STATIC_DNS         (EEPROM_STATIC_GATEWAY - 4)     // static dns server ip address, 4 bytes
 #define EEPROM_MQTT_PASSWORD      (EEPROM_STATIC_DNS - 32)        // password for mqtt server, up to 32 characters (one of which is a null terminator)
 #define EEPROM_CO2_SENSITIVITY    (EEPROM_MQTT_PASSWORD - 4)      // float value, 4-bytes, the sensitivity from the sticker  [UNUSED]
-#define EEPROM_CO2_CAL_SLOPE      (EEPROM_CO2_SENSITIVITY - 4)     // float value, 4-bytes, the slope applied to the sensor   [UNUSED] 
+#define EEPROM_CO2_CAL_SLOPE      (EEPROM_CO2_SENSITIVITY - 4)     // float value, 4-bytes, the slope applied to the sensor   [UNUSED]
 #define EEPROM_CO2_CAL_OFFSET     (EEPROM_CO2_CAL_SLOPE - 4)       // float value, 4-btyes, the offset applied to the sensor
 #define EEPROM_CO_SENSITIVITY     (EEPROM_CO2_CAL_OFFSET - 4)      // float value, 4-bytes, the sensitivity from the sticker  [UNUSED]
 #define EEPROM_CO_CAL_SLOPE       (EEPROM_CO_SENSITIVITY - 4)     // float value, 4-bytes, the slope applied to the sensor   [UNUSED]
-#define EEPROM_CO_CAL_OFFSET      (EEPROM_CO_CAL_SLOPE - 4)       // float value, 4-bytes, the offset applied to the sensor  [UNUSED] 
+#define EEPROM_CO_CAL_OFFSET      (EEPROM_CO_CAL_SLOPE - 4)       // float value, 4-bytes, the offset applied to the sensor  [UNUSED]
 #define EEPROM_PRIVATE_KEY        (EEPROM_CO_CAL_OFFSET - 32)     // 32-bytes of Random Data (256-bits)
 #define EEPROM_MQTT_SERVER_NAME   (EEPROM_PRIVATE_KEY - 32)       // string, the DNS name of the MQTT server (default mqtt.opensensors.io), up to 32 characters (one of which is a null terminator)
 #define EEPROM_MQTT_USERNAME      (EEPROM_MQTT_SERVER_NAME - 32)  // string, the user name for the MQTT server (default wickeddevice), up to 32 characters (one of which is a null terminator)
@@ -200,12 +200,12 @@ uint8_t mode = MODE_OPERATIONAL;
 #define EEPROM_NTP_SERVER_NAME    (EEPROM_USE_NTP - 32)           // 32-bytes for the NTP server to use
 #define EEPROM_NTP_TZ_OFFSET_HRS  (EEPROM_NTP_SERVER_NAME - 4)    // timezone offset as a floating point value
 #define EEPROM_CO2_BASELINE_VOLTAGE_TABLE (EEPROM_NTP_TZ_OFFSET_HRS - (5*sizeof(baseline_voltage_t))) // array of (up to) five structures for baseline offset characterization over temperature
-#define EEPROM_MQTT_TOPIC_SUFFIX_ENABLED  (EEPROM_CO2_BASELINE_VOLTAGE_TABLE - 1) 
+#define EEPROM_MQTT_TOPIC_SUFFIX_ENABLED  (EEPROM_CO2_BASELINE_VOLTAGE_TABLE - 1)
 #define EEPROM_USER_LATITUDE_DEG  (EEPROM_MQTT_TOPIC_SUFFIX_ENABLED - 4) // float value, 4-bytes, user specified latitude in degrees
 #define EEPROM_USER_LONGITUDE_DEG (EEPROM_USER_LATITUDE_DEG - 4)         // float value, 4-bytes, user specified longitude in degrees
 #define EEPROM_USER_LOCATION_EN   (EEPROM_USER_LONGITUDE_DEG - 1)        // 1 means user location supercedes GPS location, anything else means GPS or bust
-#define EEPROM_2_1_0_SAMPLING_UPD (EEPROM_USER_LOCATION_EN - 1)          // 1 means to sampling parameter default changes have been applied
-#define EEPROM_DISABLE_SOFTAP     (EEPROM_2_1_0_SAMPLING_UPD - 1)        // 1 means to disable softap behavior
+#define EEPROM_2_2_0_SAMPLING_UPD (EEPROM_USER_LOCATION_EN - 1)          // 1 means to sampling parameter default changes have been applied
+#define EEPROM_DISABLE_SOFTAP     (EEPROM_2_2_0_SAMPLING_UPD - 1)        // 1 means to disable softap behavior
 //  /\
 //   L Add values up here by subtracting offsets to previously added values
 //   * ... and make sure the addresses don't collide and start overlapping!
@@ -390,7 +390,7 @@ PGM_P const commands[] PROGMEM = {
   cmd_string_altitude,
   cmd_string_ntpsrv,
   cmd_string_tz_off,
-  cmd_string_co2_blv, 
+  cmd_string_co2_blv,
   cmd_string_usr_lat,
   cmd_string_usr_lng,
   cmd_string_usr_loc_en,
@@ -410,9 +410,9 @@ void (*command_functions[])(char * arg) = {
   set_static_ip_address,
   use_command,
   set_mqtt_server,
-  set_mqtt_port,  
+  set_mqtt_port,
   set_mqtt_username,
-  set_mqtt_password,  
+  set_mqtt_password,
   set_mqtt_client_id,
   set_mqtt_authentication,
   set_mqtt_topic_prefix,
@@ -455,7 +455,7 @@ unsigned long previous_sensor_sampling_millis = 0;
 unsigned long previous_touch_sampling_millis = 0;
 const long touch_sampling_interval = 200;
 
-// progress dots timer intervals  
+// progress dots timer intervals
 unsigned long previous_progress_dots_millis = 0;
 const long progress_dots_interval = 1000;
 
@@ -465,11 +465,11 @@ const uint8_t heartbeat_waveform[NUM_HEARTBEAT_WAVEFORM_SAMPLES] PROGMEM = {
   95, 96, 95, 94, 95, 96, 95, 97, 105, 112,
   117, 119, 120, 117, 111, 103, 95, 94, 95, 96,
   95, 94, 100, 131, 162, 193, 224, 255, 244, 214,
-  183, 152, 121, 95, 88, 80, 71, 74, 82, 90, 
-  96, 95, 94, 95, 96, 97, 106, 113, 120, 125, 
+  183, 152, 121, 95, 88, 80, 71, 74, 82, 90,
+  96, 95, 94, 95, 96, 97, 106, 113, 120, 125,
   129, 132, 133, 131, 128, 124, 118, 111, 103, 96,
-  95, 96, 95, 94, 95, 96, 95, 94, 95, 99, 
-  105, 106, 101, 96  
+  95, 96, 95, 94, 95, 96, 95, 94, 95, 99,
+  105, 106, 101, 96
 };
 uint8_t heartbeat_waveform_index = 0;
 
@@ -492,53 +492,53 @@ uint8_t mqtt_suffix_enabled = 0;
 
 const char * header_row = "Timestamp,"
                "Temperature[degC],"
-               "Humidity[percent],"                   
-               "CO2[ppm],"                    
+               "Humidity[percent],"
+               "CO2[ppm],"
                "Latitude[deg],"
                "Longitude[deg],"
-               "Altitude[m]";     
-  
+               "Altitude[m]";
+
 void setup() {
   boolean integrity_check_passed = false;
   boolean mirrored_config_mismatch = false;
-  boolean valid_ssid_passed = false; 
-  
+  boolean valid_ssid_passed = false;
+
   // initialize hardware
-  initializeHardware(); 
+  initializeHardware();
   backlightOff();
-      
+
   //  uint8_t tmp[EEPROM_CONFIG_MEMORY_SIZE] = {0};
   //  get_eeprom_config(tmp);
   //  Serial.println(F("EEPROM Config:"));
   //  dump_config(tmp);
   //  Serial.println();
   //  Serial.println(F("Mirrored Config:"));
-  //  get_mirrored_config(tmp);  
+  //  get_mirrored_config(tmp);
   //  dump_config(tmp);
   //  Serial.println();
-  
+
   integrity_check_passed = checkConfigIntegrity();
   // if the integrity check failed, try and undo the damage using the mirror config, if it's valid
   if(!integrity_check_passed){
     Serial.println(F("Info: Startup config integrity check failed, attempting to restore from mirrored configuration."));
     allowed_to_write_config_eeprom = true;
-    mirrored_config_restore_and_validate(); 
+    mirrored_config_restore_and_validate();
     integrity_check_passed = checkConfigIntegrity();
     mirrored_config_mismatch = !mirrored_config_matches_eeprom_config();
     allowed_to_write_config_eeprom = false;
   }
   else if(!mirrored_config_matches_eeprom_config()){
-    // probably the reason you got into this case is because you changed settings 
+    // probably the reason you got into this case is because you changed settings
     // in CLI mode but failed to connect to a network afterwards
     // so this will revert the Egg to use its last settings that *did* connect to a network
     Serial.println(F("Info: Startup config integrity check passed, but mirrored config differs, attempting to restore from mirrored configuration."));
     allowed_to_write_config_eeprom = true;
-    mirrored_config_restore_and_validate(); 
+    mirrored_config_restore_and_validate();
     integrity_check_passed = checkConfigIntegrity();
     mirrored_config_mismatch = !mirrored_config_matches_eeprom_config();
     allowed_to_write_config_eeprom = false;
-  }     
-  
+  }
+
   // possible outcomes of the above code
   // integrity_check_passed && mirrored_config_mismatch
   //   means... mirror configuration is not yet valid
@@ -550,15 +550,15 @@ void setup() {
   // !integrity_check_passed && !mirrored_config_mismatch
   //   means... all attempts to attain a valid configuration faile
   //            and the mirrored config is *identical* to the eeprom config
-  valid_ssid_passed = valid_ssid_config();  
-  boolean ok_to_exit_config_mode = true;   
-  
+  valid_ssid_passed = valid_ssid_config();
+  boolean ok_to_exit_config_mode = true;
+
   // if a software update introduced new settings
   // they should be populated with defaults as necessary
   initializeNewConfigSettings();
 
-  user_location_override = (eeprom_read_byte((const uint8_t *) EEPROM_USER_LOCATION_EN) == 1) ? true : false;  
-  uint8_t target_mode = eeprom_read_byte((const uint8_t *) EEPROM_OPERATIONAL_MODE);       
+  user_location_override = (eeprom_read_byte((const uint8_t *) EEPROM_USER_LOCATION_EN) == 1) ? true : false;
+  uint8_t target_mode = eeprom_read_byte((const uint8_t *) EEPROM_OPERATIONAL_MODE);
 
   // config mode processing loop
   do{
@@ -576,11 +576,11 @@ void setup() {
                   " OR CONNECT USB "));
     boolean soft_ap_config_activated = false;
     boolean touch_detected = false;
-    current_millis = millis();     
+    current_millis = millis();
     while (current_millis < start + startup_time_period) { // can get away with this sort of thing at start up
       current_millis = millis();
 
-      if(touch_detected && (eeprom_read_byte((uint8_t *) EEPROM_DISABLE_SOFTAP) != 1)){     
+      if(touch_detected && (eeprom_read_byte((uint8_t *) EEPROM_DISABLE_SOFTAP) != 1)){
         soft_ap_config_activated = true;
         Serial.println();
         Serial.println(F("Info: Entering SoftAP Mode for Configuration"));
@@ -589,18 +589,18 @@ void setup() {
 
       if(current_millis - previous_touch_sampling_millis >= touch_sampling_interval){
         static uint8_t num_touch_intervals = 0;
-        previous_touch_sampling_millis = current_millis;    
-        collectTouch();    
+        previous_touch_sampling_millis = current_millis;
+        collectTouch();
         touch_detected = processTouchQuietly();
-        
+
         num_touch_intervals++;
         if(num_touch_intervals == 5){
-          petWatchdog(); 
+          petWatchdog();
           num_touch_intervals = 0;
         }
-        
-      }      
-    
+
+      }
+
       if (Serial.available()) {
         if (got_serial_input == false) {
           Serial.println();
@@ -622,9 +622,9 @@ void setup() {
           Serial.print(countdown_value_display);
           Serial.print(F("..."));
         }
-        
+
         updateCornerDot();
-        
+
         min_over += 1000;
       }
     }
@@ -632,18 +632,18 @@ void setup() {
 
     if(soft_ap_config_activated){
       configInject("aqe\r");
-      do{            
-        allowed_to_write_config_eeprom = true;        
+      do{
+        allowed_to_write_config_eeprom = true;
         doSoftApModeConfigBehavior();
-        valid_ssid_passed = valid_ssid_config();                                       
-      } while(!valid_ssid_passed && mode_requires_wifi(target_mode)); 
+        valid_ssid_passed = valid_ssid_config();
+      } while(!valid_ssid_passed && mode_requires_wifi(target_mode));
       configInject("exit\r");
       initEsp8266();
     }
-    else{   
-      valid_ssid_passed = valid_ssid_config();  
-    
-      // check for initial integrity of configuration in eeprom      
+    else{
+      valid_ssid_passed = valid_ssid_config();
+
+      // check for initial integrity of configuration in eeprom
       if((mode != MODE_CONFIG) && mode_requires_wifi(target_mode) && !valid_ssid_passed){
 
         Serial.println(F("Info: No valid SSID configured, automatically falling back to CONFIG mode."));
@@ -651,59 +651,59 @@ void setup() {
         Serial.println();
 
         if(eeprom_read_byte((uint8_t *) EEPROM_DISABLE_SOFTAP) != 1){
-          // if you're not already in config mode, and if softap is allowed, 
+          // if you're not already in config mode, and if softap is allowed,
           // and if your operational mode requires wifi
           // and if you don't have a viable ssid configured
-          // then offer the soft ap mode until you are you have a valid SSID          
-          do{            
+          // then offer the soft ap mode until you are you have a valid SSID
+          do{
             allowed_to_write_config_eeprom = true;
             doSoftApModeConfigBehavior();
-            valid_ssid_passed = valid_ssid_config();                                       
-          } while(!valid_ssid_passed);          
+            valid_ssid_passed = valid_ssid_config();
+          } while(!valid_ssid_passed);
         }
         else{
-          // if you're not already in config mode, and if softap is NOT allowed, 
+          // if you're not already in config mode, and if softap is NOT allowed,
           // and if your operational mode requires wifi
           // and if you don't have a viable ssid configured
           // then coerce terminal-based config mode
           setLCD_P(PSTR("PLEASE CONFIGURE"
                         "NETWORK SETTINGS"));
           delay(LCD_ERROR_MESSAGE_DELAY);
-                    
+
           configInject("aqe\r");
-          Serial.println();           
-          mode = MODE_CONFIG;                      
+          Serial.println();
+          mode = MODE_CONFIG;
         }
       }
-      else if(!integrity_check_passed) { 
+      else if(!integrity_check_passed) {
         // we have no choice but to offer config mode to the user
         Serial.println(F("Info: Config memory integrity check failed, automatically falling back to CONFIG mode."));
         configInject("aqe\r");
         Serial.println();
         setLCD_P(PSTR("CONFIG INTEGRITY"
                       "  CHECK FAILED  "));
-        mode = MODE_CONFIG;        
-      }          
+        mode = MODE_CONFIG;
+      }
     }
-    
-    
+
+
     Serial.println();
     delayForWatchdog();
-    
-    while((mode == MODE_CONFIG) || (mode_requires_wifi(target_mode) && !valid_ssid_passed) ) {      
-      allowed_to_write_config_eeprom = true;   
+
+    while((mode == MODE_CONFIG) || (mode_requires_wifi(target_mode) && !valid_ssid_passed) ) {
+      allowed_to_write_config_eeprom = true;
       const uint32_t idle_timeout_period_ms = 1000UL * 60UL * 5UL; // 5 minutes
       uint32_t idle_time_ms = 0;
       Serial.println(F("-~=* In CONFIG Mode *=~-"));
       if(integrity_check_passed && valid_ssid_passed){
         setLCD_P(PSTR("  CONFIG MODE"));
-      }          
-      
+      }
+
       Serial.print(F("OPERATIONAL mode begins automatically after "));
       Serial.print((idle_timeout_period_ms / 1000UL) / 60UL);
       Serial.println(F(" mins without input."));
       Serial.println(F("Enter 'help' for a list of available commands, "));
-  
+
       configInject("get settings\r");
       Serial.println();
       Serial.println(F(" @=============================================================@"));
@@ -713,16 +713,16 @@ void setup() {
       Serial.println(F(" #   Then type 'pwd your_network_password' & press <enter>     #"));
       Serial.println(F(" #   Then type 'get settings' & press <enter> to review config #"));
       Serial.println(F(" #   Finally, type 'exit' to go into OPERATIONAL mode,         #"));
-      Serial.println(F(" #     and verify that the Egg connects to your network!       #")); 
+      Serial.println(F(" #     and verify that the Egg connects to your network!       #"));
       Serial.println(F(" @=============================================================@"));
-  
+
       prompt();
       for (;;) {
         current_millis = millis();
         if(current_millis - previous_touch_sampling_millis >= touch_sampling_interval){
-          previous_touch_sampling_millis = current_millis;   
-          collectTouch();    
-          processTouchQuietly();  
+          previous_touch_sampling_millis = current_millis;
+          collectTouch();
+          processTouchQuietly();
         }
 
         // check to determine if we have a GPS
@@ -732,12 +732,12 @@ void setup() {
             gps_installed = true;
           }
         }
-  
+
         // stuck in this loop until the command line receives an exit command
         if(mode != MODE_CONFIG){
           break; // if a command changes mode, we're done with config
         }
-        
+
         if (Serial.available()) {
           idle_time_ms = 0;
           // if you get serial traffic, pass it along to the configModeStateMachine for consumption
@@ -745,66 +745,66 @@ void setup() {
             break;
           }
         }
-  
-        // pet the watchdog once a second      
+
+        // pet the watchdog once a second
         if (current_millis - previous_tinywdt_millis >= tinywdt_interval) {
           idle_time_ms += tinywdt_interval;
           petWatchdog();
           previous_tinywdt_millis = current_millis;
         }
-  
+
         if (idle_time_ms >= idle_timeout_period_ms) {
           Serial.println(F("Info: Idle time expired, exiting CONFIG mode."));
           break;
         }
       }
 
-      valid_ssid_passed = valid_ssid_config(); 
+      valid_ssid_passed = valid_ssid_config();
       if(valid_ssid_passed){
         break;
       }
     }
-    
+
     integrity_check_passed = checkConfigIntegrity();
-    valid_ssid_passed = valid_ssid_config();    
+    valid_ssid_passed = valid_ssid_config();
     ok_to_exit_config_mode = true;
-    
-    target_mode = eeprom_read_byte((const uint8_t *) EEPROM_OPERATIONAL_MODE);      
-       
+
+    target_mode = eeprom_read_byte((const uint8_t *) EEPROM_OPERATIONAL_MODE);
+
     if(!integrity_check_passed){
       ok_to_exit_config_mode = false;
     }
     else if(mode_requires_wifi(target_mode) && !valid_ssid_passed){
       ok_to_exit_config_mode = false;
     }
-    
+
   } while(!ok_to_exit_config_mode);
 
   allowed_to_write_config_eeprom = false;
-  
+
   Serial.println(F("-~=* In OPERATIONAL Mode *=~-"));
   setLCD_P(PSTR("OPERATIONAL MODE"));
   SUCCESS_MESSAGE_DELAY();
-  
+
   // ... but *which* operational mode are we in?
   mode = target_mode;
-  
+
   // ... and what is the temperature and humdidity offset we should use
   reported_temperature_offset_degC = eeprom_read_float((float *) EEPROM_TEMPERATURE_OFFSET);
   reported_humidity_offset_percent = eeprom_read_float((float *) EEPROM_HUMIDITY_OFFSET);
-  
+
   boolean use_ntp = eeprom_read_byte((uint8_t *) EEPROM_USE_NTP);
   boolean shutdown_wifi = !mode_requires_wifi(mode);
-  
+
   if(mode_requires_wifi(mode) || use_ntp){
     shutdown_wifi = false;
-    
-    // Scan Networks to show RSSI    
-    uint8_t connect_method = eeprom_read_byte((const uint8_t *) EEPROM_CONNECT_METHOD);    
-    displayRSSI();         
+
+    // Scan Networks to show RSSI
+    uint8_t connect_method = eeprom_read_byte((const uint8_t *) EEPROM_CONNECT_METHOD);
+    displayRSSI();
     delayForWatchdog();
     petWatchdog();
-    
+
     // Try and Connect to the Configured Network
     if(!restartWifi()){
       // technically this code should be unreachable
@@ -817,14 +817,14 @@ void setup() {
     }
     delayForWatchdog();
     petWatchdog();
-  
+
     // at this point we have connected to the network successfully
     // it's an opportunity to mirror the eeprom configuration
     // if it's different from what's already there
-    // importantly this check only happens at startup    
+    // importantly this check only happens at startup
     commitConfigToMirroredConfig();
-  
-    // Check for Firmware Updates 
+
+    // Check for Firmware Updates
     checkForFirmwareUpdates();
     integrity_check_passed = checkConfigIntegrity();
     if(!integrity_check_passed){
@@ -835,9 +835,9 @@ void setup() {
         // prevent automatic reset
         delay(1000);
         petWatchdog();
-      }      
+      }
     }
-    
+
     if(use_ntp){
       getNetworkTime();
     }
@@ -848,10 +848,10 @@ void setup() {
         setLCD_P(PSTR("  MQTT CONNECT  "
                       "     FAILED     "));
         lcdFrownie(15, 1);
-        ERROR_MESSAGE_DELAY();      
+        ERROR_MESSAGE_DELAY();
         Serial.println(F("Error: Unable to connect to MQTT server"));
         Serial.flush();
-        watchdogForceReset();    
+        watchdogForceReset();
       }
       delayForWatchdog();
       petWatchdog();
@@ -865,26 +865,26 @@ void setup() {
     // it's a mode that doesn't require Wi-Fi
     // save settings as necessary
     commitConfigToMirroredConfig();
-    esp.sleep(2); // deep sleep    
+    esp.sleep(2); // deep sleep
   }
-  
+
   // get the temperature units
   temperature_units = eeprom_read_byte((const uint8_t *) EEPROM_TEMPERATURE_UNITS);
   if((temperature_units != 'C') && (temperature_units != 'F')){
     temperature_units = 'C';
   }
-  
+
   // get the sampling, reporting, and averaging parameters
   sampling_interval = eeprom_read_word((uint16_t * ) EEPROM_SAMPLING_INTERVAL) * 1000L;
   reporting_interval = eeprom_read_word((uint16_t * ) EEPROM_REPORTING_INTERVAL) * 1000L;
   sample_buffer_depth = (uint16_t) ((((uint32_t) eeprom_read_word((uint16_t * ) EEPROM_AVERAGING_INTERVAL)) * 1000L) / sampling_interval);
-  
+
   if(mode == SUBMODE_NORMAL){
     setLCD_P(PSTR("TEMP ---  RH ---"
-                  "CO2  ---        "));           
-    SUCCESS_MESSAGE_DELAY();                      
+                  "CO2  ---        "));
+    SUCCESS_MESSAGE_DELAY();
   }
-  
+
   resumeGpsProcessing();
 }
 
@@ -897,40 +897,40 @@ void loop() {
     // hardware doesn't matter in this case
     updateGpsStrings();
   }
-  else if(!gps_disabled){       
-    while(gpsSerial.available()){            
+  else if(!gps_disabled){
+    while(gpsSerial.available()){
       char c = gpsSerial.read();
 
       if(c == '$'){
         gps_installed = true;
       }
-      
+
       if(gps.encode(c)){
         gps.f_get_position(&gps_latitude, &gps_longitude, &gps_age);
         gps_altitude = gps.f_altitude();
-        updateGpsStrings();        
+        updateGpsStrings();
         break;
       }
     }
-  }   
-    
+  }
+
   if(current_millis - previous_sensor_sampling_millis >= sampling_interval){
     suspendGpsProcessing();
-    previous_sensor_sampling_millis = current_millis;    
+    previous_sensor_sampling_millis = current_millis;
     //Serial.print(F("Info: Sampling Sensors @ "));
     //Serial.println(millis());
-    collectCO2();    
+    collectCO2();
     collectTemperature();
-    collectHumidity(); 
-    advanceSampleBufferIndex(); 
+    collectHumidity();
+    advanceSampleBufferIndex();
   }
 
   if(current_millis - previous_touch_sampling_millis >= touch_sampling_interval){
     suspendGpsProcessing();
-    previous_touch_sampling_millis = current_millis;    
-    collectTouch();    
-    processTouchQuietly();  
-  }  
+    previous_touch_sampling_millis = current_millis;
+    collectTouch();
+    processTouchQuietly();
+  }
 
   // the following loop routines *must* return reasonably frequently
   // so that the watchdog timer is serviced
@@ -941,10 +941,10 @@ void loop() {
     case SUBMODE_OFFLINE:
       loop_offline_mode();
       break;
-    default: // unkown operating mode, nothing to be done 
+    default: // unkown operating mode, nothing to be done
       break;
   }
-  
+
   // pet the watchdog
   if (current_millis - previous_tinywdt_millis >= tinywdt_interval) {
     suspendGpsProcessing();
@@ -969,18 +969,18 @@ void SUCCESS_MESSAGE_DELAY(void){
 }
 
 void init_firmware_version(void){
-  snprintf(firmware_version, 15, "%d.%d.%d", 
-    AQEV2FW_MAJOR_VERSION, 
-    AQEV2FW_MINOR_VERSION, 
+  snprintf(firmware_version, 15, "%d.%d.%d",
+    AQEV2FW_MAJOR_VERSION,
+    AQEV2FW_MINOR_VERSION,
     AQEV2FW_PATCH_VERSION);
 }
 
 void initEsp8266(void){
   uint8_t connect_method = eeprom_read_byte((const uint8_t *) EEPROM_CONNECT_METHOD);
-  Serial.print(F("Info: ESP8266 Initialization..."));  
-    
+  Serial.print(F("Info: ESP8266 Initialization..."));
+
   esp.setTcpKeepAliveInterval(10); // 10 seconds
-  esp.setInputBuffer(esp8266_input_buffer, ESP8266_INPUT_BUFFER_SIZE); // connect the input buffer up   
+  esp.setInputBuffer(esp8266_input_buffer, ESP8266_INPUT_BUFFER_SIZE); // connect the input buffer up
   if (esp.reset()) {
     esp.setNetworkMode(1);
     Serial.println(F("OK."));
@@ -989,7 +989,7 @@ void initEsp8266(void){
   else {
     Serial.println(F("Failed."));
     init_esp8266_ok = false;
-  }  
+  }
 }
 
 void initializeHardware(void) {
@@ -997,15 +997,15 @@ void initializeHardware(void) {
   Serial1.begin(115200);
 
   init_firmware_version();
-  
+
   // without this line, if the touch hardware is absent
   // serial input processing grinds to a snails pace
-  touch.set_CS_Timeout_Millis(100); 
+  touch.set_CS_Timeout_Millis(100);
   touch.set_CS_AutocaL_Millis(5000);
 
   Serial.println(F(" +------------------------------------+"));
   Serial.println(F(" |   Welcome to Air Quality Egg 2.0   |"));
-  Serial.println(F(" |         CO2 Sensor Suite           |"));  
+  Serial.println(F(" |         CO2 Sensor Suite           |"));
   Serial.print(F(" |       Firmware Version "));
   Serial.print(firmware_version);
   Serial.println(F("       |"));
@@ -1015,7 +1015,7 @@ void initializeHardware(void) {
   Serial.print(F(" Egg Serial Number: "));
   print_eeprom_mqtt_client_id();
   Serial.println();
-  
+
   // Initialize Tiny Watchdog
   Serial.print(F("Info: Tiny Watchdog Initialization..."));
   watchdogInitialize();
@@ -1041,7 +1041,7 @@ void initializeHardware(void) {
           B00000,
           B00000
   };
-  
+
   byte frownie[8] = {
           B00000,
           B00000,
@@ -1052,7 +1052,7 @@ void initializeHardware(void) {
           B00000,
           B00000
   };
-  
+
   byte emptybar[8] = {
           B11111,
           B10001,
@@ -1063,7 +1063,7 @@ void initializeHardware(void) {
           B10001,
           B11111
   };
-  
+
   byte fullbar[8] = {
           B11111,
           B11111,
@@ -1073,24 +1073,24 @@ void initializeHardware(void) {
           B11111,
           B11111,
           B11111
-  };     
+  };
 
   lcd.begin(16, 2);
-  
+
   lcd.createChar(0, smiley);
-  lcd.createChar(1, frownie);  
+  lcd.createChar(1, frownie);
   lcd.createChar(2, emptybar);
   lcd.createChar(3, fullbar);
-    
+
   setLCD_P(PSTR("AIR QUALITY EGG "));
   char tmp[17] = {0};
-  snprintf(tmp, 16, "VERSION %d.%d.%d", 
-    AQEV2FW_MAJOR_VERSION, 
+  snprintf(tmp, 16, "VERSION %d.%d.%d",
+    AQEV2FW_MAJOR_VERSION,
     AQEV2FW_MINOR_VERSION,
     AQEV2FW_PATCH_VERSION);
-    
+
   updateLCD(tmp, 1);
-  
+
   Wire.begin();
 
   // Initialize slot select pins
@@ -1098,7 +1098,7 @@ void initializeHardware(void) {
   pinMode(7, OUTPUT);
   selectNoSlot();
   Serial.println(F("OK."));
-  
+
   // Initialize SPI Flash
   Serial.print(F("Info: SPI Flash Initialization..."));
   if (flash.initialize()) {
@@ -1108,17 +1108,17 @@ void initializeHardware(void) {
   else {
     Serial.println(F("Fail."));
     init_spi_flash_ok = false;
-  }  
-  
+  }
+
   // Initialize SD card
-  Serial.print(F("Info: SD Card Initialization..."));        
+  Serial.print(F("Info: SD Card Initialization..."));
   if (SD.begin(16)) {
-    Serial.println(F("OK."));     
-    init_sdcard_ok = true;        
+    Serial.println(F("OK."));
+    init_sdcard_ok = true;
   }
   else{
-    Serial.println(F("Fail.")); 
-    init_sdcard_ok = false;  
+    Serial.println(F("Fail."));
+    init_sdcard_ok = false;
   }
 
   getCurrentFirmwareSignature();
@@ -1135,17 +1135,17 @@ void initializeHardware(void) {
   }
 
   // Initialize SD card
-  Serial.print(F("Info: RTC Initialization..."));   
-  selectSlot3();  
+  Serial.print(F("Info: RTC Initialization..."));
+  selectSlot3();
   rtc.begin();
   if (rtc.isrunning()) {
-    Serial.println(F("OK."));   
-    setSyncProvider(AQE_now);  
-    init_rtc_ok = true;       
+    Serial.println(F("OK."));
+    setSyncProvider(AQE_now);
+    init_rtc_ok = true;
   }
   else{
-    Serial.println(F("Fail.")); 
-    init_rtc_ok = false;  
+    Serial.println(F("Fail."));
+    init_rtc_ok = false;
   }
 
   selectNoSlot();
@@ -1153,7 +1153,7 @@ void initializeHardware(void) {
   petWatchdog();
   SUCCESS_MESSAGE_DELAY(); // don't race past the splash screen, and give watchdog some breathing room
   initEsp8266();
-    
+
   updateLCD("CO2", 0);
   updateLCD("MODEL", 1);
   SUCCESS_MESSAGE_DELAY();
@@ -1163,32 +1163,32 @@ void initializeHardware(void) {
   // for CO2 software serial to work
   // must be some source of constructor
   pinMode(9, INPUT_PULLUP);
-  pinMode(10, OUTPUT);  
+  pinMode(10, OUTPUT);
 
-  // put the same thing in for the GPS pins 
+  // put the same thing in for the GPS pins
   // just to be on the safe side
   pinMode(18, INPUT_PULLUP);
   pinMode(17, OUTPUT);
-    
+
 }
 
 /****** CONFIGURATION SUPPORT FUNCTIONS ******/
 void initializeNewConfigSettings(void){
   char * command_buf = &(scratch[0]);
   clearTempBuffers();
-  
-  boolean in_config_mode = false; 
+
+  boolean in_config_mode = false;
   allowed_to_write_config_eeprom = true;
 
 
   // if necessary, initialize the default mqtt prefix
   // if it's never been set, the first byte in memory will be 0xFF
-  uint8_t val = eeprom_read_byte((const uint8_t *) EEPROM_MQTT_TOPIC_PREFIX);  
+  uint8_t val = eeprom_read_byte((const uint8_t *) EEPROM_MQTT_TOPIC_PREFIX);
   if(val == 0xFF){
     if(!in_config_mode){
       configInject("aqe\r");
       in_config_mode = true;
-    }    
+    }
     memset(command_buf, 0, 128);
     strcat(command_buf, "mqttprefix ");
     strcat(command_buf, MQTT_TOPIC_PREFIX);
@@ -1203,48 +1203,48 @@ void initializeNewConfigSettings(void){
     if(!in_config_mode){
       configInject("aqe\r");
       in_config_mode = true;
-    }    
+    }
     configInject("mqttsrv mqtt.opensensors.io\r");
   }
-  
+
   // if the mqtt suffix enable is neither zero nor one, set it to one (enabled)
-  val = eeprom_read_byte((const uint8_t *) EEPROM_MQTT_TOPIC_SUFFIX_ENABLED);  
+  val = eeprom_read_byte((const uint8_t *) EEPROM_MQTT_TOPIC_SUFFIX_ENABLED);
   if(val == 0xFF){
     if(!in_config_mode){
       configInject("aqe\r");
       in_config_mode = true;
-    }    
+    }
     memset(command_buf, 0, 128);
-    strcat(command_buf, "mqttsuffix enable\r");        
-    configInject(command_buf);    
+    strcat(command_buf, "mqttsuffix enable\r");
+    configInject(command_buf);
   }
-  
-  val = eeprom_read_byte((const uint8_t *) EEPROM_2_1_0_SAMPLING_UPD);
+
+  val = eeprom_read_byte((const uint8_t *) EEPROM_2_2_0_SAMPLING_UPD);
   if(val != 1){
     if(!in_config_mode){
       configInject("aqe\r");
       in_config_mode = true;
     }
 
-    configInject("softap enable\r");                
+    configInject("softap enable\r");
     configInject("sampling 5, 60, 60\r");
-    eeprom_write_byte((uint8_t *) EEPROM_2_1_0_SAMPLING_UPD, 1);
+    eeprom_write_byte((uint8_t *) EEPROM_2_2_0_SAMPLING_UPD, 1);
 
     // check if ntpsrv is pool.ntp.org, and if so, switch it to 0.airqualityegg.pool.ntp.org
-    memset(command_buf, 0, 128);  
+    memset(command_buf, 0, 128);
     eeprom_write_block(command_buf, (void *) EEPROM_NTP_SERVER_NAME, 32);
-    if(strcmp(command_buf, "pool.ntp.org") == 0){      
+    if(strcmp(command_buf, "pool.ntp.org") == 0){
       configInject("ntpsrv 0.airqualityegg.pool.ntp.org\r");
-    }    
-    
+    }
+
     recomputeAndStoreConfigChecksum();
   }
-  
+
   if(in_config_mode){
     configInject("exit\r");
   }
-  
-  allowed_to_write_config_eeprom = false;  
+
+  allowed_to_write_config_eeprom = false;
 }
 
 boolean checkConfigIntegrity(void) {
@@ -1327,7 +1327,7 @@ uint8_t configModeStateMachine(char b, boolean reset_buffers) {
 
     // Serial.print("buf = ");
     // Serial.println(buf);
-    
+
     if (strncmp("aqe", lower_buf, 3) == 0) {
       ret = CONFIG_MODE_GOT_INIT;
     }
@@ -1378,8 +1378,8 @@ uint8_t configModeStateMachine(char b, boolean reset_buffers) {
         boolean command_found = false;
         char _temp_command[16] = {0};
         uint8_t ii = 0;
-        do{    
-          strcpy_P(_temp_command, (PGM_P) pgm_read_word(&(commands[ii])));    
+        do{
+          strcpy_P(_temp_command, (PGM_P) pgm_read_word(&(commands[ii])));
           if (strncmp(_temp_command, lower_buf, strlen(buf)) == 0) {
             command_functions[ii](first_arg);
             command_found = true;
@@ -1456,17 +1456,17 @@ void lowercase(char * str) {
 
 void note_know_what_youre_doing(){
   Serial.println(F("   note:    Unless you *really* know what you're doing, you should"));
-  Serial.println(F("            probably not be using this command."));  
+  Serial.println(F("            probably not be using this command."));
 }
 
 void warn_could_break_upload(){
   Serial.println(F("   warning: Using this command incorrectly can prevent your device"));
-  Serial.println(F("            from publishing data to the internet."));  
+  Serial.println(F("            from publishing data to the internet."));
 }
 
 void warn_could_break_connect(){
   Serial.println(F("   warning: Using this command incorrectly can prevent your device"));
-  Serial.println(F("            from connecting to your network."));  
+  Serial.println(F("            from connecting to your network."));
 }
 
 void defaults_help_indent(void){
@@ -1488,10 +1488,10 @@ void help_menu(char * arg) {
     Serial.print(F("help    \texit    \t"));
     char _temp_command[16] = {0};
     uint8_t ii = 0;
-    uint8_t jj = first_dynamic_command_index;     
-    do{        
+    uint8_t jj = first_dynamic_command_index;
+    do{
       strcpy_P(_temp_command, (PGM_P) pgm_read_word(&(commands[ii])));
-      
+
       if ((jj % commands_per_line) == 0) {
         Serial.println();
       }
@@ -1500,7 +1500,7 @@ void help_menu(char * arg) {
       Serial.print(_temp_command);
       Serial.print('\t');
 
-      ii++; 
+      ii++;
       jj++;
     } while(_temp_command[0] != 0);
     Serial.println();
@@ -1551,7 +1551,7 @@ boolean valid_ssid_config(void) {
   char ssid[33] = {0};
   boolean ssid_contains_only_printables = true;
 
-  uint8_t connect_method = eeprom_read_byte((const uint8_t *) EEPROM_CONNECT_METHOD);    
+  uint8_t connect_method = eeprom_read_byte((const uint8_t *) EEPROM_CONNECT_METHOD);
   eeprom_read_block(ssid, (const void *) EEPROM_SSID, 32);
   for (uint8_t ii = 0; ii <= 32; ii++) {
     if (ssid[ii] == '\0') {
@@ -1621,13 +1621,13 @@ void print_eeprom_ipmode(void) {
   eeprom_read_block(netmask, (const void *) EEPROM_STATIC_NETMASK, 4);
   eeprom_read_block(gateway, (const void *) EEPROM_STATIC_GATEWAY, 4);
   eeprom_read_block(dns, (const void *) EEPROM_STATIC_DNS, 4);
-  
+
   if (memcmp(ip, noip, 4) == 0) {
     Serial.println(F("Configured for DHCP"));
   }
   else {
     Serial.println(F("Configured for Static IP: "));
-    for(uint8_t param_idx = 0; param_idx < 4; param_idx++){         
+    for(uint8_t param_idx = 0; param_idx < 4; param_idx++){
       for (uint8_t ii = 0; ii < 4; ii++) {
         switch(param_idx){
           case 0:
@@ -1651,18 +1651,18 @@ void print_eeprom_ipmode(void) {
           case 3:
             if(ii == 0){
               Serial.print(F("   DNS Server:      "));
-            }         
-            Serial.print(dns[ii], DEC); 
+            }
+            Serial.print(dns[ii], DEC);
             break;
-        }   
-        
-        if( ii != 3 ){        
+        }
+
+        if( ii != 3 ){
           Serial.print(F("."));
         }
         else{
-          Serial.println(); 
+          Serial.println();
         }
-      }      
+      }
     }
   }
 }
@@ -1713,7 +1713,7 @@ void print_eeprom_ntp_server(){
 
 void print_eeprom_update_filename(){
   print_eeprom_string((const char *) EEPROM_UPDATE_FILENAME);
-}  
+}
 
 void print_eeprom_mqtt_server(){
   print_eeprom_string((const char *) EEPROM_MQTT_SERVER_NAME);
@@ -1749,16 +1749,16 @@ void print_eeprom_mqtt_username(){
 void print_eeprom_mqtt_authentication(){
   uint8_t auth = eeprom_read_byte((uint8_t *) EEPROM_MQTT_AUTH);
   if(auth){
-    Serial.println(F("    MQTT Authentication: Enabled"));    
+    Serial.println(F("    MQTT Authentication: Enabled"));
     Serial.print(F("    MQTT Username: "));
-    print_eeprom_mqtt_username();              
+    print_eeprom_mqtt_username();
   }
   else{
     Serial.println(F("    MQTT Authentication: Disabled"));
   }
 }
 
-void print_eeprom_operational_mode(uint8_t opmode){   
+void print_eeprom_operational_mode(uint8_t opmode){
   switch (opmode) {
     case SUBMODE_NORMAL:
       Serial.println(F("Normal"));
@@ -1774,10 +1774,10 @@ void print_eeprom_operational_mode(uint8_t opmode){
       Serial.print(opmode, HEX);
       Serial.println(F("]"));
       break;
-  }  
+  }
 }
 
-void print_eeprom_temperature_units(){   
+void print_eeprom_temperature_units(){
   uint8_t tempunit = eeprom_read_byte((uint8_t *) EEPROM_TEMPERATURE_UNITS);
   switch (tempunit) {
     case 'C':
@@ -1794,14 +1794,14 @@ void print_eeprom_temperature_units(){
       Serial.print(tempunit, HEX);
       Serial.println(F("]"));
       break;
-  }  
+  }
 }
 
 void print_altitude_settings(void){
   int16_t l_altitude = (int16_t) eeprom_read_word((uint16_t *) EEPROM_ALTITUDE_METERS);
   if(l_altitude != -1){
     Serial.print(l_altitude);
-    Serial.println(F(" meters"));  
+    Serial.println(F(" meters"));
   }
   else{
     Serial.println("Not set");
@@ -1813,7 +1813,7 @@ void print_latitude_settings(void){
   float f_latitude = eeprom_read_float((float *) EEPROM_USER_LATITUDE_DEG);
   if(l_latitude != -1){
     Serial.print(f_latitude, 6);
-    Serial.println(F(" degrees"));  
+    Serial.println(F(" degrees"));
   }
   else{
     Serial.println("Not set");
@@ -1825,14 +1825,14 @@ void print_longitude_settings(void){
   float f_longitude = eeprom_read_float((float *) EEPROM_USER_LONGITUDE_DEG);
   if(l_longitude != -1){
     Serial.print(f_longitude, 6);
-    Serial.println(F(" degrees"));  
+    Serial.println(F(" degrees"));
   }
   else{
     Serial.println("Not set");
   }
 }
 
-void print_eeprom_backlight(){   
+void print_eeprom_backlight(){
   uint16_t backlight_duration = eeprom_read_word((uint16_t *) EEPROM_BACKLIGHT_DURATION);
   uint8_t backlight_startup = eeprom_read_byte((uint8_t *) EEPROM_BACKLIGHT_STARTUP);
   Serial.print(backlight_duration);
@@ -1842,15 +1842,15 @@ void print_eeprom_backlight(){
       Serial.println(F("ON at startup"));
       break;
     case BACKLIGHT_OFF_AT_STARTUP:
-      Serial.println(F("OFF at startup"));    
+      Serial.println(F("OFF at startup"));
       break;
     case BACKLIGHT_ALWAYS_ON:
-      Serial.println(F("always ON"));    
+      Serial.println(F("always ON"));
       break;
     case BACKLIGHT_ALWAYS_OFF:
-      Serial.println(F("always OFF"));        
+      Serial.println(F("always OFF"));
       break;
-  }   
+  }
 }
 
 void print_eeprom_value(char * arg) {
@@ -1871,27 +1871,27 @@ void print_eeprom_value(char * arg) {
   }
   else if (strncmp(arg, "temp_off", 8) == 0) {
     print_eeprom_float((const float *) EEPROM_TEMPERATURE_OFFSET);
-  }  
+  }
   else if (strncmp(arg, "hum_off", 7) == 0) {
     print_eeprom_float((const float *) EEPROM_HUMIDITY_OFFSET);
   }
   else if (strncmp(arg, "co2_off", 7) == 0) {
     print_eeprom_float((const float *) EEPROM_CO2_CAL_OFFSET);
-  }    
+  }
   else if(strncmp(arg, "mqttsrv", 7) == 0) {
-    print_eeprom_string((const char *) EEPROM_MQTT_SERVER_NAME);    
+    print_eeprom_string((const char *) EEPROM_MQTT_SERVER_NAME);
   }
   else if(strncmp(arg, "mqttport", 8) == 0) {
-    Serial.println(eeprom_read_dword((const uint32_t *) EEPROM_MQTT_PORT));      
-  }  
+    Serial.println(eeprom_read_dword((const uint32_t *) EEPROM_MQTT_PORT));
+  }
   else if(strncmp(arg, "mqttuser", 8) == 0) {
-    print_eeprom_string((const char *) EEPROM_MQTT_USERNAME);    
-  }  
+    print_eeprom_string((const char *) EEPROM_MQTT_USERNAME);
+  }
   else if(strncmp(arg, "mqttid", 6) == 0) {
-    print_eeprom_string((const char *) EEPROM_MQTT_CLIENT_ID);    
+    print_eeprom_string((const char *) EEPROM_MQTT_CLIENT_ID);
   }
   else if(strncmp(arg, "mqttauth", 8) == 0) {
-    Serial.println(eeprom_read_byte((const uint8_t *) EEPROM_MQTT_AUTH));    
+    Serial.println(eeprom_read_byte((const uint8_t *) EEPROM_MQTT_AUTH));
   }
   else if(strncmp(arg, "opmode", 6) == 0) {
      print_eeprom_operational_mode(eeprom_read_byte((const uint8_t *) EEPROM_OPERATIONAL_MODE));
@@ -1905,34 +1905,34 @@ void print_eeprom_value(char * arg) {
   else if(strncmp(arg, "timestamp", 9) == 0) {
     printCurrentTimestamp(NULL, NULL);
     Serial.println();
-  } 
+  }
   else if(strncmp(arg, "updatesrv", 9) == 0) {
-    print_eeprom_update_server();    
-  }  
+    print_eeprom_update_server();
+  }
   else if(strncmp(arg, "ntpsrv", 6) == 0) {
-    print_eeprom_ntp_server();    
-  }  
+    print_eeprom_ntp_server();
+  }
   else if(strncmp(arg, "updatefile", 10) == 0) {
-    print_eeprom_string((const char *) EEPROM_UPDATE_FILENAME);    
-  }  
+    print_eeprom_string((const char *) EEPROM_UPDATE_FILENAME);
+  }
   else if(strncmp(arg, "sampleint", 9) == 0) {
-    Serial.println(eeprom_read_word((uint16_t *) EEPROM_SAMPLING_INTERVAL));    
-  }   
+    Serial.println(eeprom_read_word((uint16_t *) EEPROM_SAMPLING_INTERVAL));
+  }
   else if(strncmp(arg, "reportint", 9) == 0) {
-    Serial.println(eeprom_read_word((uint16_t *) EEPROM_REPORTING_INTERVAL));    
-  }     
+    Serial.println(eeprom_read_word((uint16_t *) EEPROM_REPORTING_INTERVAL));
+  }
   else if(strncmp(arg, "avgint", 6) == 0) {
-    Serial.println(eeprom_read_word((uint16_t *) EEPROM_AVERAGING_INTERVAL));    
-  } 
+    Serial.println(eeprom_read_word((uint16_t *) EEPROM_AVERAGING_INTERVAL));
+  }
   else if(strncmp(arg, "altitude", 8) == 0) {
-    Serial.println((int16_t) eeprom_read_word((uint16_t *) EEPROM_ALTITUDE_METERS));    
-  }         
+    Serial.println((int16_t) eeprom_read_word((uint16_t *) EEPROM_ALTITUDE_METERS));
+  }
   else if(strncmp(arg, "latitude", 8) == 0) {
-    Serial.println((int16_t) eeprom_read_float((float *) EEPROM_USER_LATITUDE_DEG));    
+    Serial.println((int16_t) eeprom_read_float((float *) EEPROM_USER_LATITUDE_DEG));
   }
   else if(strncmp(arg, "longitude", 8) == 0) {
-    Serial.println((int16_t) eeprom_read_float((float *) EEPROM_USER_LONGITUDE_DEG));    
-  }             
+    Serial.println((int16_t) eeprom_read_float((float *) EEPROM_USER_LONGITUDE_DEG));
+  }
   else if(strncmp(arg, "settings", 8) == 0) {
     // print all the settings to the screen in an orderly fashion
     Serial.println(F(" +-------------------------------------------------------------+"));
@@ -1945,13 +1945,13 @@ void print_eeprom_value(char * arg) {
     Serial.print(F("    Backlight Settings: "));
     print_eeprom_backlight();
     Serial.print(F("    Sensor Sampling Interval: "));
-    Serial.print(eeprom_read_word((uint16_t *) EEPROM_SAMPLING_INTERVAL));  
+    Serial.print(eeprom_read_word((uint16_t *) EEPROM_SAMPLING_INTERVAL));
     Serial.println(F(" seconds"));
     Serial.print(F("    Sensor Averaging Interval: "));
-    Serial.print(eeprom_read_word((uint16_t *) EEPROM_AVERAGING_INTERVAL));  
+    Serial.print(eeprom_read_word((uint16_t *) EEPROM_AVERAGING_INTERVAL));
     Serial.println(F(" seconds"));
     Serial.print(F("    Sensor Reporting Interval: "));
-    Serial.print(eeprom_read_word((uint16_t *) EEPROM_REPORTING_INTERVAL));  
+    Serial.print(eeprom_read_word((uint16_t *) EEPROM_REPORTING_INTERVAL));
     Serial.println(F(" seconds"));
     Serial.print(F("    SoftAP Config: "));
     if(eeprom_read_byte((const uint8_t *) EEPROM_DISABLE_SOFTAP) == 1){
@@ -1971,7 +1971,7 @@ void print_eeprom_value(char * arg) {
     }
     else{
       Serial.println(F("Disabled"));
-    }  
+    }
 
     Serial.print(F("    GPS: "));
     if(gps_installed){
@@ -1979,22 +1979,22 @@ void print_eeprom_value(char * arg) {
     }
     else{
       Serial.println(F("Not installed"));
-    } 
- 
+    }
+
     Serial.print(F("    User Latitude: "));
     print_latitude_settings();
     Serial.print(F("    User Longitude: "));
     print_longitude_settings();
     Serial.print(F("    User Altitude: "));
-    print_altitude_settings();    
-    
+    print_altitude_settings();
+
     Serial.println(F(" +-------------------------------------------------------------+"));
     Serial.println(F(" | Network Settings:                                           |"));
     Serial.println(F(" +-------------------------------------------------------------+"));
     print_label_with_star_if_not_backed_up("MAC Address: ", BACKUP_STATUS_MAC_ADDRESS_BIT);
     print_eeprom_mac();
     uint8_t connect_method = eeprom_read_byte((const uint8_t *) EEPROM_CONNECT_METHOD);
-    Serial.print(F("    Method: "));    
+    Serial.print(F("    Method: "));
     print_eeprom_connect_method();
     Serial.print(F("    SSID: "));
     print_eeprom_ssid();
@@ -2003,9 +2003,9 @@ void print_eeprom_value(char * arg) {
     Serial.print(F("    IP Mode: "));
     print_eeprom_ipmode();
     Serial.print(F("    Update Server: "));
-    print_eeprom_update_server();    
+    print_eeprom_update_server();
     Serial.print(F("    Update Filename: "));
-    print_eeprom_update_filename();        
+    print_eeprom_update_filename();
     Serial.print(F("    NTP Server: "));
     if(eeprom_read_byte((uint8_t *) EEPROM_USE_NTP) == 1){
       print_eeprom_ntp_server();
@@ -2015,21 +2015,21 @@ void print_eeprom_value(char * arg) {
     }
     print_label_with_star_if_not_backed_up("NTP TZ Offset: ", BACKUP_STATUS_TIMEZONE_CALIBRATION_BIT);
     print_eeprom_float((const float *) EEPROM_NTP_TZ_OFFSET_HRS);
-    
+
     Serial.println(F(" +-------------------------------------------------------------+"));
     Serial.println(F(" | MQTT Settings:                                              |"));
-    Serial.println(F(" +-------------------------------------------------------------+"));    
+    Serial.println(F(" +-------------------------------------------------------------+"));
     Serial.print(F("    MQTT Server: "));
-    print_eeprom_mqtt_server();   
+    print_eeprom_mqtt_server();
     Serial.print(F("    MQTT Port: "));
-    Serial.println(eeprom_read_dword((const uint32_t *) EEPROM_MQTT_PORT)); 
+    Serial.println(eeprom_read_dword((const uint32_t *) EEPROM_MQTT_PORT));
     Serial.print(F("    MQTT Client ID: "));
-    print_eeprom_mqtt_client_id();       
-    print_eeprom_mqtt_authentication(); 
+    print_eeprom_mqtt_client_id();
+    print_eeprom_mqtt_authentication();
     Serial.print(F("    MQTT Topic Prefix: "));
     print_eeprom_mqtt_topic_prefix();
     Serial.print(F("    MQTT Topic Suffix: "));
-    print_eeprom_mqtt_topic_suffix();      
+    print_eeprom_mqtt_topic_suffix();
     Serial.println(F(" +-------------------------------------------------------------+"));
     Serial.println(F(" | Credentials:                                                |"));
     Serial.println(F(" +-------------------------------------------------------------+"));
@@ -2047,7 +2047,7 @@ void print_eeprom_value(char * arg) {
     print_baseline_voltage_characterization(EEPROM_CO2_BASELINE_VOLTAGE_TABLE);
     char temp_reporting_offset_label[64] = {0};
     char temperature_units = (char) eeprom_read_byte((uint8_t *) EEPROM_TEMPERATURE_UNITS);
-    snprintf(temp_reporting_offset_label, 63, "Temperature Reporting Offset [deg%c]: ", temperature_units); 
+    snprintf(temp_reporting_offset_label, 63, "Temperature Reporting Offset [deg%c]: ", temperature_units);
     float temp_reporting_offset_degc = eeprom_read_float((float *) EEPROM_TEMPERATURE_OFFSET);
     float temperature_offset_display = temp_reporting_offset_degc;
     if(temperature_units == 'F'){
@@ -2055,11 +2055,11 @@ void print_eeprom_value(char * arg) {
     }
     print_label_with_star_if_not_backed_up((char * )temp_reporting_offset_label, BACKUP_STATUS_TEMPERATURE_CALIBRATION_BIT);
     Serial.println(temperature_offset_display, 2);
-    
+
     print_label_with_star_if_not_backed_up("Humidity Reporting Offset [%]: ", BACKUP_STATUS_HUMIDITY_CALIBRATION_BIT);
-    Serial.println(eeprom_read_float((float *) EEPROM_HUMIDITY_OFFSET), 2);  
-    
-    
+    Serial.println(eeprom_read_float((float *) EEPROM_HUMIDITY_OFFSET), 2);
+
+
     Serial.println(F(" +-------------------------------------------------------------+"));
     Serial.println(F(" | note: '*' next to label means the setting is not backed up. |"));
     Serial.println(F(" |     run 'backup all' when you are satisfied                 |"));
@@ -2098,7 +2098,7 @@ void restore(char * arg) {
   if(!configMemoryUnlocked(__LINE__)){
     return;
   }
-  
+
   char blank[32] = {0};
   uint8_t tmp[32] = {0};
   boolean valid = true;
@@ -2107,7 +2107,7 @@ void restore(char * arg) {
   // 1. MAC address              0x80
   // 2. MQTT Password            0x40
   // 3. Private Key              0x20
-  // 4. CO2 Calibration Values   0x10  
+  // 4. CO2 Calibration Values   0x10
 
   uint16_t backup_check = eeprom_read_word((const uint16_t *) EEPROM_BACKUP_CHECK);
 
@@ -2118,13 +2118,13 @@ void restore(char * arg) {
     configInject("security auto\r");
     configInject("use dhcp\r");
     configInject("opmode normal\r");
-    configInject("tempunit C\r");    
-    configInject("altitude -1\r");    
+    configInject("tempunit C\r");
+    configInject("altitude -1\r");
     configInject("backlight 60\r");
     configInject("backlight initon\r");
     configInject("mqttsrv mqtt.opensensors.io\r");
-    configInject("mqttport 1883\r");        
-    configInject("mqttauth enable\r");    
+    configInject("mqttport 1883\r");
+    configInject("mqttauth enable\r");
     configInject("mqttuser wickeddevice\r");
     configInject("mqttprefix /orgs/wd/aqe/\r");
     configInject("mqttsuffix enable\r");
@@ -2133,19 +2133,19 @@ void restore(char * arg) {
     configInject("ntpsrv 0.airqualityegg.pool.ntp.org\r");
     configInject("restore tz_off\r");
     configInject("restore temp_off\r");
-    configInject("restore hum_off\r");       
+    configInject("restore hum_off\r");
     configInject("restore mqttpwd\r");
     configInject("restore mqttid\r");
     configInject("restore updatesrv\r");
-    configInject("restore updatefile\r");    
+    configInject("restore updatefile\r");
     configInject("restore key\r");
     configInject("restore co2\r");
     configInject("restore mac\r");
 
     eeprom_write_block(blank, (void *) EEPROM_SSID, 32); // clear the SSID
     eeprom_write_block(blank, (void *) EEPROM_NETWORK_PWD, 32); // clear the Network Password
-    mirrored_config_erase(); // erase the mirrored configuration, which will be restored next successful network connect                            
-    
+    mirrored_config_erase(); // erase the mirrored configuration, which will be restored next successful network connect
+
     Serial.println();
   }
   else if (strncmp(arg, "mac", 3) == 0) {
@@ -2181,7 +2181,7 @@ void restore(char * arg) {
     eeprom_write_block(tmp, (void *) EEPROM_MQTT_PASSWORD, 32);
   }
   else if (strncmp("mqttid", arg, 6) == 0) {
-    // get the 8-byte unique electronic ID from the SHT25 
+    // get the 8-byte unique electronic ID from the SHT25
     // convert it to a string, and store it to EEPROM
     uint8_t serial_number[8];
     sht25.getSerialNumber(serial_number);
@@ -2196,15 +2196,15 @@ void restore(char * arg) {
       serial_number[7]);
 
     lowercase((char *) tmp); // for consistency with aqe v1 and airqualityegg.com assumptions
-    
+
     eeprom_write_block(tmp, (void *) EEPROM_MQTT_CLIENT_ID, 32);
-  }  
+  }
   else if (strncmp("updatesrv", arg, 9) == 0) {
     eeprom_write_block("update.wickeddevice.com", (void *) EEPROM_UPDATE_SERVER_NAME, 32);
-  }  
+  }
   else if (strncmp("updatefile", arg, 10) == 0) {
     eeprom_write_block("aqev2_co2_esp", (void *) EEPROM_UPDATE_FILENAME, 32);
-  }  
+  }
   else if (strncmp("key", arg, 3) == 0) {
     if (!BIT_IS_CLEARED(backup_check, BACKUP_STATUS_PRIVATE_KEY_BIT)) {
       Serial.println(F("Error: Private key must be backed up  "));
@@ -2229,17 +2229,17 @@ void restore(char * arg) {
     if (!BIT_IS_CLEARED(backup_check, BACKUP_STATUS_TEMPERATURE_CALIBRATION_BIT)) {
       Serial.println(F("Error: Temperature reporting offset should be backed up  "));
       Serial.println(F("       prior to executing a 'restore'. Setting to 0.0"));
-      eeprom_write_float((float *) EEPROM_TEMPERATURE_OFFSET, 0.0f);  
+      eeprom_write_float((float *) EEPROM_TEMPERATURE_OFFSET, 0.0f);
     }
     else{
       eeprom_read_block(tmp, (const void *) EEPROM_BACKUP_TEMPERATURE_OFFSET, 4);
       eeprom_write_block(tmp, (void *) EEPROM_TEMPERATURE_OFFSET, 4);
     }
   }
-  else if (strncmp("hum_off", arg, 7) == 0) {   
+  else if (strncmp("hum_off", arg, 7) == 0) {
     if (!BIT_IS_CLEARED(backup_check, BACKUP_STATUS_HUMIDITY_CALIBRATION_BIT)) {
       Serial.println(F("Warning: Humidity reporting offset should be backed up  "));
-      Serial.println(F("         prior to executing a 'restore'. Setting to 0.0."));   
+      Serial.println(F("         prior to executing a 'restore'. Setting to 0.0."));
       eeprom_write_float((float *) EEPROM_HUMIDITY_OFFSET, 0.0f);
     }
     else{
@@ -2247,10 +2247,10 @@ void restore(char * arg) {
       eeprom_write_block(tmp, (void *) EEPROM_HUMIDITY_OFFSET, 4);
     }
   }
-  else if(strncmp("tz_off", arg, 6) == 0) {   
+  else if(strncmp("tz_off", arg, 6) == 0) {
     if (!BIT_IS_CLEARED(backup_check, BACKUP_STATUS_TIMEZONE_CALIBRATION_BIT)) {
       Serial.println(F("Warning: Timezone offset should be backed up  "));
-      Serial.println(F("         prior to executing a 'restore'. Setting to 0.0."));   
+      Serial.println(F("         prior to executing a 'restore'. Setting to 0.0."));
       eeprom_write_float((float *) EEPROM_NTP_TZ_OFFSET_HRS, 0.0f);
     }
     else{
@@ -2272,14 +2272,14 @@ void restore(char * arg) {
 }
 
 void set_backlight_behavior(char * arg){
-  boolean valid = true;  
-  
+  boolean valid = true;
+
   if(!configMemoryUnlocked(__LINE__)){
     return;
   }
-  
+
   lowercase(arg);
-  
+
   if(strncmp(arg, "initon", 6) == 0){
     eeprom_write_byte((uint8_t *) EEPROM_BACKLIGHT_STARTUP, BACKLIGHT_ON_AT_STARTUP);
   }
@@ -2291,18 +2291,18 @@ void set_backlight_behavior(char * arg){
   }
   else if(strncmp(arg, "alwaysoff", 9) == 0){
     eeprom_write_byte((uint8_t *) EEPROM_BACKLIGHT_STARTUP, BACKLIGHT_ALWAYS_OFF);
-  }  
-  else{ 
+  }
+  else{
     boolean arg_contains_only_digits = true;
     char * ptr = arg;
-    uint16_t arglen = strlen(arg);    
+    uint16_t arglen = strlen(arg);
     for(uint16_t ii = 0; ii < arglen; ii++){
       if(!isdigit(arg[ii])){
         arg_contains_only_digits = true;
-        break; 
+        break;
       }
     }
-    
+
     if(arg_contains_only_digits){
       uint32_t duration = (uint32_t) strtoul(arg, NULL, 10);
       if(duration < 0xFFFF){
@@ -2313,13 +2313,13 @@ void set_backlight_behavior(char * arg){
       valid = false;
       Serial.print(F("Error: Unexpected paramater name \""));
       Serial.print(arg);
-      Serial.println(F("\""));      
+      Serial.println(F("\""));
     }
   }
-  
+
   if (valid) {
     recomputeAndStoreConfigChecksum();
-  }  
+  }
 }
 
 void altitude_command(char * arg){
@@ -2342,11 +2342,11 @@ void altitude_command(char * arg){
 void sampling_command(char * arg){
   if(!configMemoryUnlocked(__LINE__)){
     return;
-  } 
+  }
 
   uint16_t len = strlen(arg);
-  uint8_t num_commas = 0;  
-  
+  uint8_t num_commas = 0;
+
   for(uint16_t ii = 0; ii < len; ii++){
     // if any character is not a space, comma, or digit it's unparseable
     if((!isdigit(arg[ii])) && (arg[ii] != ' ') && (arg[ii] != ',')){
@@ -2360,41 +2360,41 @@ void sampling_command(char * arg){
     if(arg[ii] == ','){
       num_commas++;
     }
-  }    
-    
+  }
+
   if(num_commas != 2){
     Serial.print(F("Error: sampling expects exactly 3 values separated by commas, but received "));
     Serial.print(num_commas - 1);
     Serial.println();
-    return; 
-  }  
-  
+    return;
+  }
+
   // ok we have 3 numeric arguments separated by commas, parse them
   // ok we have six numeric arguments separated by commas, parse them
-  char tmp[32] = {0};  
+  char tmp[32] = {0};
   strncpy(tmp, arg, 31); // copy the string so you don't mutilate the argument
   char * token = strtok(tmp, ",");
-  uint8_t token_number = 0;  
+  uint8_t token_number = 0;
   uint16_t l_sample_interval = 0;
   uint16_t l_averaging_interval = 0;
   uint16_t l_reporting_interval = 0;
-  
+
   while (token != NULL) {
     switch(token_number++){
       case 0:
         l_sample_interval = (uint16_t) strtoul(token, NULL, 10);
         if(l_sample_interval < 1){
-          Serial.print(F("Error: Sampling interval must be greater than 0 [was ")); 
+          Serial.print(F("Error: Sampling interval must be greater than 0 [was "));
           Serial.print(l_sample_interval);
           Serial.print(F("]"));
           Serial.println();
           return;
         }
-        break;      
+        break;
       case 1:
         l_averaging_interval = (uint16_t) strtoul(token, NULL, 10);
         if(l_averaging_interval < 1){
-          Serial.print(F("Error: Averaging interval must be greater than 0 [was ")); 
+          Serial.print(F("Error: Averaging interval must be greater than 0 [was "));
           Serial.print(l_averaging_interval);
           Serial.print(F("]"));
           Serial.println();
@@ -2403,23 +2403,23 @@ void sampling_command(char * arg){
         else if((l_averaging_interval % l_sample_interval) != 0){
           Serial.print(F("Error: Averaging interval must be an integer multiple of the Sampling interval"));
           Serial.println();
-          return;          
+          return;
         }
         else if((l_averaging_interval / l_sample_interval) > MAX_SAMPLE_BUFFER_DEPTH){
           Serial.print(F("Error: Insufficient memory available for averaging interval @ sampling interval."));
-          Serial.print(F("       Must require no more than "));          
+          Serial.print(F("       Must require no more than "));
           Serial.print(MAX_SAMPLE_BUFFER_DEPTH);
           Serial.print(F(" samples, but requires"));
           Serial.print(l_averaging_interval / l_sample_interval);
           Serial.println(F(" samples"));
           Serial.println();
-          return;                    
+          return;
         }
         break;
       case 2:
         l_reporting_interval = (uint16_t) strtoul(token, NULL, 10);
         if(l_reporting_interval < 1){
-          Serial.print(F("Error: Reporting interval must be greater than 0 [was ")); 
+          Serial.print(F("Error: Reporting interval must be greater than 0 [was "));
           Serial.print(l_reporting_interval);
           Serial.print(F("]"));
           Serial.println();
@@ -2428,29 +2428,29 @@ void sampling_command(char * arg){
         else if((l_reporting_interval % l_sample_interval) != 0){
           Serial.print(F("Error: Reporting interval must be an integer multiple of the Sampling interval"));
           Serial.println();
-          return;          
-        }        
+          return;
+        }
         break;
-    }    
-    
+    }
+
     token = strtok(NULL, ",");
-  } 
-  
+  }
+
   // we got through all the checks! save these parameters to config memory
   eeprom_write_word((uint16_t *) EEPROM_SAMPLING_INTERVAL, l_sample_interval);
   eeprom_write_word((uint16_t *) EEPROM_REPORTING_INTERVAL, l_reporting_interval);
   eeprom_write_word((uint16_t *) EEPROM_AVERAGING_INTERVAL, l_averaging_interval);
-  recomputeAndStoreConfigChecksum();  
+  recomputeAndStoreConfigChecksum();
 }
 
 void AQE_set_datetime(char * arg){
   if(!configMemoryUnlocked(__LINE__)){
     return;
-  } 
-  
+  }
+
   uint16_t len = strlen(arg);
-  uint8_t num_commas = 0;  
-  
+  uint8_t num_commas = 0;
+
   for(uint16_t ii = 0; ii < len; ii++){
     // if any character is not a space, comma, or digit it's unparseable
     if((!isdigit(arg[ii])) && (arg[ii] != ' ') && (arg[ii] != ',')){
@@ -2460,43 +2460,43 @@ void AQE_set_datetime(char * arg){
       Serial.println();
       return;
     }
-    
+
     if(arg[ii] == ','){
       num_commas++;
     }
   }
- 
+
   if(num_commas != 5){
     Serial.print(F("Error: datetime expects exactly 6 values separated by commas, but received "));
     Serial.print(num_commas - 1);
     Serial.println();
-    return; 
+    return;
   }
-  
+
   // ok we have six numeric arguments separated by commas, parse them
-  char tmp[32] = {0};  
+  char tmp[32] = {0};
   strncpy(tmp, arg, 31); // copy the string so you don't mutilate the argument
   char * token = strtok(tmp, ",");
-  uint8_t token_number = 0;  
+  uint8_t token_number = 0;
   uint8_t mo = 0, dy = 0, hr = 0, mn = 0, sc = 0;
   uint16_t yr = 0;
-  
+
   while (token != NULL) {
     switch(token_number++){
       case 0:
         yr = (uint16_t) strtoul(token, NULL, 10);
         if(yr < 2015){
-          Serial.print(F("Error: Year must be no earlier than 2015 [was ")); 
+          Serial.print(F("Error: Year must be no earlier than 2015 [was "));
           Serial.print(yr);
           Serial.print(F("]"));
           Serial.println();
           return;
         }
-        break;      
+        break;
       case 1:
         mo = (uint8_t) strtoul(token, NULL, 10);
         if(mo < 1 || mo > 12){
-          Serial.print(F("Error: Month must be between 1 and 12 [was ")); 
+          Serial.print(F("Error: Month must be between 1 and 12 [was "));
           Serial.print(mo);
           Serial.print(F("]"));
           Serial.println();
@@ -2506,73 +2506,73 @@ void AQE_set_datetime(char * arg){
       case 2:
         dy = (uint8_t) strtoul(token, NULL, 10);
         if(dy < 1 || dy > 31){
-          Serial.print(F("Error: Day must be between 1 and 31 [was ")); 
+          Serial.print(F("Error: Day must be between 1 and 31 [was "));
           Serial.print(dy);
           Serial.print(F("]"));
           Serial.println();
           return;
-        }        
+        }
         break;
       case 3:
-        hr = (uint8_t) strtoul(token, NULL, 10);    
+        hr = (uint8_t) strtoul(token, NULL, 10);
         if(hr > 23){
-          Serial.print(F("Error: Hour must be between 0 and 23 [was ")); 
+          Serial.print(F("Error: Hour must be between 0 and 23 [was "));
           Serial.print(hr);
           Serial.print(F("]"));
           Serial.println();
           return;
-        }        
+        }
         break;
       case 4:
-        mn = (uint8_t) strtoul(token, NULL, 10);  
+        mn = (uint8_t) strtoul(token, NULL, 10);
         if(mn > 59){
-          Serial.print(F("Error: Minute must be between 0 and 59 [was ")); 
+          Serial.print(F("Error: Minute must be between 0 and 59 [was "));
           Serial.print(mn);
           Serial.print(F("]"));
           Serial.println();
           return;
-        }        
+        }
         break;
       case 5:
-        sc = (uint8_t) strtoul(token, NULL, 10);      
+        sc = (uint8_t) strtoul(token, NULL, 10);
         if(mn > 59){
-          Serial.print(F("Error: Second must be between 0 and 59 [was ")); 
+          Serial.print(F("Error: Second must be between 0 and 59 [was "));
           Serial.print(sc);
           Serial.print(F("]"));
           Serial.println();
           return;
-        }          
-        break;        
+        }
+        break;
     }
     token = strtok(NULL, ",");
   }
-  
+
   // if we have an RTC set the time in the RTC
   DateTime datetime(yr,mo,dy,hr,mn,sc);
-  
+
   // it's not harmful to do this
   // even if the RTC is not present
   selectSlot3();
   rtc.adjust(datetime);
-  
+
   // also clear the Oscillator Stop Flag
   // this should really be folded into the RTCLib code
   rtcClearOscillatorStopFlag();
-  
-      
+
+
   // at any rate sync the time to this
   setTime(datetime.unixtime());
-  
+
 }
 
 void set_mac_address(char * arg) {
   if(!configMemoryUnlocked(__LINE__)){
     return;
-  }  
-  
+  }
+
   uint8_t _mac_address[6] = {0};
   char tmp[32] = {0};
-  
+
   strncpy(tmp, arg, 31); // copy the string so you don't mutilate the argument
   char * token = strtok(tmp, ":");
   uint8_t num_tokens = 0;
@@ -2585,8 +2585,8 @@ void set_mac_address(char * arg) {
       Serial.println(arg);
       Serial.println();
       return;
-    }    
-    
+    }
+
     if ((strlen(token) == 2) && isxdigit(token[0]) && isxdigit(token[1]) && (num_tokens < 6)) {
       _mac_address[num_tokens++] = (uint8_t) strtoul(token, NULL, 16);
     }
@@ -2597,7 +2597,7 @@ void set_mac_address(char * arg) {
       return; // return early
     }
 
-    
+
     token = strtok(NULL, ":");
   }
 
@@ -2613,8 +2613,8 @@ void set_mac_address(char * arg) {
 void set_connection_method(char * arg) {
   if(!configMemoryUnlocked(__LINE__)){
     return;
-  }  
-  
+  }
+
   lowercase(arg);
   boolean valid = true;
   if (strncmp(arg, "direct", 6) == 0) {
@@ -2637,7 +2637,7 @@ void set_ssid(char * arg) {
   if(!configMemoryUnlocked(__LINE__)){
     return;
   }
-  
+
   // we've reserved 32-bytes of EEPROM for an SSID
   // so the argument's length must be <= 31
   char ssid[33] = {0};
@@ -2656,7 +2656,7 @@ void set_network_password(char * arg) {
   if(!configMemoryUnlocked(__LINE__)){
     return;
   }
-  
+
   // we've reserved 32-bytes of EEPROM for a network password
   // so the argument's length must be <= 31
   char password[32] = {0};
@@ -2675,7 +2675,7 @@ void set_network_security_mode(char * arg) {
   if(!configMemoryUnlocked(__LINE__)){
     return;
   }
-  
+
   boolean valid = true;
   if (strncmp("open", arg, 4) == 0) {
     eeprom_write_byte((uint8_t *) EEPROM_SECURITY_MODE, 0);
@@ -2710,7 +2710,7 @@ void set_operational_mode(char * arg) {
   if(!configMemoryUnlocked(__LINE__)){
     return;
   }
-  
+
   boolean valid = true;
   if (strncmp("normal", arg, 6) == 0) {
     eeprom_write_byte((uint8_t *) EEPROM_OPERATIONAL_MODE, SUBMODE_NORMAL);
@@ -2734,15 +2734,15 @@ void set_operational_mode(char * arg) {
 void set_temperature_units(char * arg){
   if(!configMemoryUnlocked(__LINE__)){
     return;
-  }  
-  
+  }
+
   if((strlen(arg) != 1) || ((arg[0] != 'C') && (arg[0] != 'F'))){
     Serial.print(F("Error: temperature unit must be 'C' or 'F', but received '"));
     Serial.print(arg);
     Serial.println(F("'"));
     return;
-  }  
-  
+  }
+
   eeprom_write_byte((uint8_t *) EEPROM_TEMPERATURE_UNITS, arg[0]);
   recomputeAndStoreConfigChecksum();
 }
@@ -2750,19 +2750,19 @@ void set_temperature_units(char * arg){
 void set_static_ip_address(char * arg) {
   if(!configMemoryUnlocked(__LINE__)){
     return;
-  }  
-  
+  }
+
   uint8_t _ip_address[4] = {0};
   uint8_t _gateway_ip[4] = {0};
-  uint8_t _dns_ip[4] = {0}; 
+  uint8_t _dns_ip[4] = {0};
   uint8_t _netmask[4] = {0};
-  
+
   char tmp[128] = {0};
   strncpy(tmp, arg, 127); // copy the string so you don't mutilate the argument
   char * params[4] = {0};
   uint8_t param_idx = 0;
-  
-  // first tokenize on spaces, you should end up with four strings     
+
+  // first tokenize on spaces, you should end up with four strings
   char * token = strtok(tmp, " ");
   uint8_t num_tokens = 0;
 
@@ -2775,23 +2775,23 @@ void set_static_ip_address(char * arg) {
       Serial.println();
       return;
     }
-    params[param_idx++] = token;   
-    token = strtok(NULL, " "); 
+    params[param_idx++] = token;
+    token = strtok(NULL, " ");
   }
-  
+
   if(param_idx != 4){
      Serial.println(F("Error: Too few parameters passed to staticip"));
      Serial.print(F("       "));
      Serial.println(arg);
-     configInject("help staticip\r");   
-     Serial.println();     
+     configInject("help staticip\r");
+     Serial.println();
      return;
   }
 
   for(param_idx = 0; param_idx < 4; param_idx++){
     token = strtok(params[param_idx], ".");
-    num_tokens = 0;    
-    
+    num_tokens = 0;
+
     // parse the parameter string, expected to be of the form 192.168.1.52
     while (token != NULL) {
       uint8_t tokenlen = strlen(token);
@@ -2818,9 +2818,9 @@ void set_static_ip_address(char * arg) {
               break;
             case 3:
               _dns_ip[num_tokens++] = octet;
-              break; 
+              break;
             default:
-              break;            
+              break;
           }
         }
         else {
@@ -2834,12 +2834,12 @@ void set_static_ip_address(char * arg) {
         Serial.print(F("Error: IP address parse error on input \""));
         Serial.print(token);
         Serial.println(F("\""));
-        return; 
+        return;
       }
-      
+
       token = strtok(NULL, ".");
-    }    
-      
+    }
+
     if (num_tokens != 4){
       Serial.print(F("Error: IP Address must contain 4 valid octets separated by '.' [@param "));
       Serial.print(param_idx + 1);
@@ -2850,12 +2850,12 @@ void set_static_ip_address(char * arg) {
   }
 
   // if we got this far, it means we got 4 valid IP addresses, and they
-  // are stored in their respective local variables    
+  // are stored in their respective local variables
   uint32_t ipAddress = esp.IpArrayToIpUint32((uint8_t *) _ip_address);
   uint32_t netMask = esp.IpArrayToIpUint32((uint8_t *) _netmask);
-  uint32_t defaultGateway = esp.IpArrayToIpUint32((uint8_t *) _gateway_ip);  
-  
-  eeprom_write_block(_ip_address, (void *) EEPROM_STATIC_IP_ADDRESS, 4);  
+  uint32_t defaultGateway = esp.IpArrayToIpUint32((uint8_t *) _gateway_ip);
+
+  eeprom_write_block(_ip_address, (void *) EEPROM_STATIC_IP_ADDRESS, 4);
   eeprom_write_block(_netmask, (void *) EEPROM_STATIC_NETMASK, 4);
   eeprom_write_block(_gateway_ip, (void *) EEPROM_STATIC_GATEWAY, 4);
   //eeprom_write_block(_dns_ip, (void *) EEPROM_STATIC_DNS, 4);
@@ -2866,7 +2866,7 @@ void use_command(char * arg) {
   if(!configMemoryUnlocked(__LINE__)){
     return;
   }
-  
+
   const uint8_t noip[4] = {0};
   if (strncmp("dhcp", arg, 4) == 0) {
     eeprom_write_block(noip, (void *) EEPROM_STATIC_IP_ADDRESS, 4);
@@ -2888,11 +2888,11 @@ void force_command(char * arg){
   if(!configMemoryUnlocked(__LINE__)){
     return;
   }
-  
-  if (strncmp("update", arg, 6) == 0) {    
+
+  if (strncmp("update", arg, 6) == 0) {
     Serial.println(F("Info: Erasing last flash page"));
-    SUCCESS_MESSAGE_DELAY();                      
-    invalidateSignature();    
+    SUCCESS_MESSAGE_DELAY();
+    invalidateSignature();
     configInject("opmode normal\r");
     mode = SUBMODE_NORMAL;
     configInject("exit\r");
@@ -2902,11 +2902,11 @@ void force_command(char * arg){
     Serial.print(arg);
     Serial.println(F("\""));
     return;
-  }  
+  }
 }
 
 void printDirectory(File dir, int numTabs) {
-   for(;;){     
+   for(;;){
      File entry =  dir.openNextFile();
      if (! entry) {
        // no more files
@@ -2924,7 +2924,7 @@ void printDirectory(File dir, int numTabs) {
      } else {
        // files have sizes, directories do not
        Serial.print(F("\t"));
-       Serial.print(F("\t"));       
+       Serial.print(F("\t"));
        Serial.println(entry.size(), DEC);
      }
      entry.close();
@@ -2935,22 +2935,22 @@ void list_command(char * arg){
   if (strncmp("files", arg, 5) == 0){
     if(init_sdcard_ok){
       File root = SD.open("/", FILE_READ);
-      printDirectory(root, 0);   
-      root.close();       
+      printDirectory(root, 0);
+      root.close();
     }
     else{
       Serial.println(F("Error: SD Card is not initialized, can't list files."));
-    }    
+    }
   }
   else{
     Serial.print(F("Error: Invalid parameter provided to 'list' command - \""));
     Serial.print(arg);
     Serial.println(F("\""));
-  }  
+  }
 }
 
 void download_one_file(char * filename){
-  if(filename != NULL && init_sdcard_ok){    
+  if(filename != NULL && init_sdcard_ok){
     File dataFile = SD.open(filename, FILE_READ);
     char last_char_read = NULL;
     if (dataFile) {
@@ -2958,23 +2958,23 @@ void download_one_file(char * filename){
         last_char_read = dataFile.read();
         Serial.write(last_char_read);
       }
-      dataFile.close();      
+      dataFile.close();
     }
     //else {
     //  Serial.print("Error: Failed to open file named \"");
     //  Serial.print(filename);
     //  Serial.print(F("\""));
-    //}    
+    //}
     if(last_char_read != '\n'){
-      Serial.println();        
+      Serial.println();
     }
-  }  
+  }
 }
 
 void crack_datetime_filename(char * filename, uint8_t target_array[4]){
-  char temp_str[3] = {0, 0, 0};   
+  char temp_str[3] = {0, 0, 0};
   for(uint8_t ii = 0; ii < 4; ii++){
-    strncpy(temp_str, &(filename[ii * 2]), 2);  
+    strncpy(temp_str, &(filename[ii * 2]), 2);
     target_array[ii] = atoi(temp_str);
   }
 
@@ -2982,11 +2982,11 @@ void crack_datetime_filename(char * filename, uint8_t target_array[4]){
 }
 
 void make_datetime_filename(uint8_t src_array[4], char * target_filename, uint8_t max_len){
-  snprintf(target_filename, max_len, "%02d%02d%02d%02d.csv", 
+  snprintf(target_filename, max_len, "%02d%02d%02d%02d.csv",
     src_array[0] - 30, // YY is offset from 2000, but epoch time is offset from 1970
     src_array[1],
     src_array[2],
-    src_array[3]);  
+    src_array[3]);
 }
 
 void advanceByOneHour(uint8_t src_array[4]){
@@ -2999,9 +2999,9 @@ void advanceByOneHour(uint8_t src_array[4]){
   tm.Hour   = src_array[3];
   tm.Minute = 0;
   tm.Second = 0;
-  
+
   time_t seconds_since_epoch = makeTime(tm);
-  seconds_since_epoch += SECS_PER_HOUR; 
+  seconds_since_epoch += SECS_PER_HOUR;
   breakTime(seconds_since_epoch, tm);
 
   src_array[0] = tm.Year;
@@ -3011,17 +3011,17 @@ void advanceByOneHour(uint8_t src_array[4]){
 }
 
 // does the behavior of executing the one_file_function on a single file
-// or on each file in a range of files 
+// or on each file in a range of files
 void fileop_command_delegate(char * arg, void (*one_file_function)(char *)){
   char * first_arg = NULL;
   char * second_arg = NULL;
-  
+
   trim_string(arg);
-  
+
   first_arg = strtok(arg, " ");
   second_arg = strtok(NULL, " ");
 
-  if(second_arg == NULL){   
+  if(second_arg == NULL){
     one_file_function(first_arg);
     }
     else {
@@ -3037,22 +3037,22 @@ void fileop_command_delegate(char * arg, void (*one_file_function)(char *)){
     const long interval = 1000;
     while(!finished_last_file){
       unsigned long currentMillis = millis();
-      if(currentMillis - previousMillis >= interval) {        
-        previousMillis = currentMillis;   
+      if(currentMillis - previousMillis >= interval) {
+        previousMillis = currentMillis;
         petWatchdog();
       }
       memset(cur_date_filename, 0, 16);
       make_datetime_filename(cur_date, cur_date_filename, 15);
       one_file_function(cur_date_filename);
-      if(memcmp(cur_date, end_date, 4) == 0){      
+      if(memcmp(cur_date, end_date, 4) == 0){
         finished_last_file = true;
-      }    
-      else{
-        advanceByOneHour(cur_date);      
       }
-    }     
-    delayForWatchdog();    
-  }  
+      else{
+        advanceByOneHour(cur_date);
+      }
+    }
+    delayForWatchdog();
+  }
 }
 
 void download_command(char * arg){
@@ -3062,7 +3062,7 @@ void download_command(char * arg){
 }
 
 void delete_one_file(char * filename){
-  if(filename != NULL && init_sdcard_ok){   
+  if(filename != NULL && init_sdcard_ok){
     if (SD.remove(filename)) {
       Serial.print("Info: Removed file named \"");
       Serial.print(filename);
@@ -3072,8 +3072,8 @@ void delete_one_file(char * filename){
 //      Serial.print("Error: Failed to delete file named \"");
 //      Serial.print(filename);
 //      Serial.println(F("\""));
-//    }    
-    }    
+//    }
+    }
   }
 
 void delete_command(char * arg){
@@ -3085,7 +3085,7 @@ void set_mqtt_password(char * arg) {
   if(!configMemoryUnlocked(__LINE__)){
     return;
   }
-  
+
   // we've reserved 32-bytes of EEPROM for a MQTT password
   // so the argument's length must be <= 31
   char password[32] = {0};
@@ -3104,7 +3104,7 @@ void set_mqtt_topic_prefix(char * arg) {
   if(!configMemoryUnlocked(__LINE__)){
     return;
   }
-  
+
   // we've reserved 64-bytes of EEPROM for a MQTT prefix
   // so the argument's length must be <= 63
   char prefix[64] = {0};
@@ -3124,7 +3124,7 @@ void set_user_latitude(char * arg){
 }
 
 void set_user_longitude(char * arg){
-  set_float_param(arg, (float *) EEPROM_USER_LONGITUDE_DEG, NULL);  
+  set_float_param(arg, (float *) EEPROM_USER_LONGITUDE_DEG, NULL);
 }
 
 void set_user_location_enable(char * arg){
@@ -3133,9 +3133,9 @@ void set_user_location_enable(char * arg){
   }
 
   lowercase(arg);
-  
+
   if (strcmp(arg, "enable") == 0){
-    eeprom_write_byte((uint8_t *) EEPROM_USER_LOCATION_EN, 1);    
+    eeprom_write_byte((uint8_t *) EEPROM_USER_LOCATION_EN, 1);
     recomputeAndStoreConfigChecksum();
   }
   else if (strcmp(arg, "disable") == 0){
@@ -3146,7 +3146,7 @@ void set_user_location_enable(char * arg){
     Serial.print(F("Error: expected 'enable' or 'disable' but got '"));
     Serial.print(arg);
     Serial.println("'");
-  }  
+  }
 
   user_location_override = eeprom_read_byte((uint8_t *) EEPROM_USER_LOCATION_EN) == 1 ? true : false;
 }
@@ -3157,9 +3157,9 @@ void set_softap_enable(char * arg){
   }
 
   lowercase(arg);
-  
+
   if (strcmp(arg, "enable") == 0){
-    eeprom_write_byte((uint8_t *) EEPROM_DISABLE_SOFTAP, 0);    
+    eeprom_write_byte((uint8_t *) EEPROM_DISABLE_SOFTAP, 0);
     recomputeAndStoreConfigChecksum();
   }
   else if (strcmp(arg, "disable") == 0){
@@ -3170,7 +3170,7 @@ void set_softap_enable(char * arg){
     Serial.print(F("Error: expected 'enable' or 'disable' but got '"));
     Serial.print(arg);
     Serial.println("'");
-  }  
+  }
 }
 
 
@@ -3180,7 +3180,7 @@ void topic_suffix_config(char * arg) {
   }
 
   lowercase(arg);
-  
+
   if (strcmp(arg, "enable") == 0){
     eeprom_write_byte((uint8_t *) EEPROM_MQTT_TOPIC_SUFFIX_ENABLED, 1);
     recomputeAndStoreConfigChecksum();
@@ -3201,7 +3201,7 @@ void set_mqtt_server(char * arg){
   if(!configMemoryUnlocked(__LINE__)){
     return;
   }
-  
+
   // we've reserved 32-bytes of EEPROM for an MQTT server name
   // so the argument's length must be <= 31
   char server[32] = {0};
@@ -3213,14 +3213,14 @@ void set_mqtt_server(char * arg){
   }
   else {
     Serial.println(F("Error: MQTT server name must be less than 32 characters in length"));
-  }  
+  }
 }
 
 void set_mqtt_username(char * arg){
   if(!configMemoryUnlocked(__LINE__)){
     return;
   }
-  
+
   // we've reserved 32-bytes of EEPROM for an MQTT username
   // so the argument's length must be <= 31
   char username[32] = {0};
@@ -3232,18 +3232,18 @@ void set_mqtt_username(char * arg){
   }
   else {
     Serial.println(F("Error: MQTT username must be less than 32 characters in length"));
-  }    
+  }
 }
 void set_mqtt_client_id(char * arg){
   if(!configMemoryUnlocked(__LINE__)){
     return;
   }
-  
+
   // we've reserved 32-bytes of EEPROM for an MQTT client ID
   // but in fact an MQTT client ID must be between 1 and 23 characters
   // and must start with an letter
-  char client_id[32] = {0};  
-  
+  char client_id[32] = {0};
+
   uint16_t len = strlen(arg);
   if ((len >= 1) && (len <= 23)) {
     strncpy(client_id, arg, len);
@@ -3255,18 +3255,18 @@ void set_mqtt_client_id(char * arg){
   }
 }
 
-void set_mqtt_authentication(char * arg) {   
+void set_mqtt_authentication(char * arg) {
   if(!configMemoryUnlocked(__LINE__)){
     return;
   }
-  
-  if (strncmp("enable", arg, 6) == 0) { 
+
+  if (strncmp("enable", arg, 6) == 0) {
     eeprom_write_byte((uint8_t *) EEPROM_MQTT_AUTH, 1);
     recomputeAndStoreConfigChecksum();
   }
-  else if(strncmp("disable", arg, 7) == 0) { 
+  else if(strncmp("disable", arg, 7) == 0) {
     eeprom_write_byte((uint8_t *) EEPROM_MQTT_AUTH, 0);
-    recomputeAndStoreConfigChecksum();    
+    recomputeAndStoreConfigChecksum();
   }
   else {
     Serial.print(F("Error: Invalid parameter provided to 'mqttauth' command - \""));
@@ -3276,28 +3276,28 @@ void set_mqtt_authentication(char * arg) {
   }
 }
 
-void set_mqtt_port(char * arg) {  
+void set_mqtt_port(char * arg) {
   if(!configMemoryUnlocked(__LINE__)){
     return;
   }
-  
+
   uint16_t len = strlen(arg);
   boolean valid = true;
-  
+
   for(uint16_t ii = 0; ii < len; ii++){
     if(!isdigit(arg[ii])){
       valid = false;
-    } 
+    }
   }
-  
+
   uint32_t port = 0xFFFFFFFF;
   if(valid){
     port = (uint32_t) strtoul(arg, NULL, 10);
   }
-  
+
   if(valid && (port < 0x10000) && (port > 0)){
     eeprom_write_dword((uint32_t *) EEPROM_MQTT_PORT, port);
-    recomputeAndStoreConfigChecksum();        
+    recomputeAndStoreConfigChecksum();
   }
   else {
     Serial.print(F("Error: Invalid parameter provided to 'mqttport' command - \""));
@@ -3311,24 +3311,24 @@ void set_update_server_name(char * arg){
 
   static char server[32] = {0};
   memset(server, 0, 32);
-  
+
   if(!configMemoryUnlocked(__LINE__)){
     return;
   }
-  
-  trim_string(arg); // leading and trailing spaces are not relevant 
-  uint16_t len = strlen(arg);   
-  
+
+  trim_string(arg); // leading and trailing spaces are not relevant
+  uint16_t len = strlen(arg);
+
   // we've reserved 32-bytes of EEPROM for an update server name
-  // so the argument's length must be <= 31      
-  if (len < 32) {        
+  // so the argument's length must be <= 31
+  if (len < 32) {
     strncpy(server, arg, 31); // copy the argument as a case-sensitive server name
     lowercase(arg);           // in case it's the "disable" special case, make arg case insensitive
-    
-    if(strncmp(arg, "disable", 7) == 0){      
-      memset(server, 0, 32); // wipe out the update server name 
+
+    if(strncmp(arg, "disable", 7) == 0){
+      memset(server, 0, 32); // wipe out the update server name
     }
-    
+
     eeprom_write_block(server, (void *) EEPROM_UPDATE_SERVER_NAME, 32);
     recomputeAndStoreConfigChecksum();
   }
@@ -3341,7 +3341,7 @@ void set_update_filename(char * arg){
   if(!configMemoryUnlocked(__LINE__)){
     return;
   }
-  
+
   // we've reserved 32-bytes of EEPROM for an update server name
   // so the argument's length must be <= 31
   char filename[32] = {0};
@@ -3353,45 +3353,45 @@ void set_update_filename(char * arg){
   }
   else {
     Serial.println(F("Error: Update filename must be less than 32 characters in length"));
-  }  
+  }
 }
 
 void set_ntp_server(char * arg){
 
   static char server[32] = {0};
   memset(server, 0, 32);
-  
+
   if(!configMemoryUnlocked(__LINE__)){
     return;
   }
-  
-  trim_string(arg); // leading and trailing spaces are not relevant 
-  uint16_t len = strlen(arg);   
-  
+
+  trim_string(arg); // leading and trailing spaces are not relevant
+  uint16_t len = strlen(arg);
+
   // we've reserved 32-bytes of EEPROM for an NTP server name
-  // so the argument's length must be <= 31      
-  if (len < 32) {        
+  // so the argument's length must be <= 31
+  if (len < 32) {
     strncpy(server, arg, 31); // copy the argument as a case-sensitive server name
     lowercase(arg);           // in case it's the "disable" special case, make arg case insensitive
-    
-    if(strncmp(arg, "disable", 7) == 0){     
-      eeprom_write_byte((uint8_t *) EEPROM_USE_NTP, 0); 
-      memset(server, 0, 32); // wipe out the NTP server name 
+
+    if(strncmp(arg, "disable", 7) == 0){
+      eeprom_write_byte((uint8_t *) EEPROM_USE_NTP, 0);
+      memset(server, 0, 32); // wipe out the NTP server name
     }
-    
+
     eeprom_write_block(server, (void *) EEPROM_NTP_SERVER_NAME, 32);
     recomputeAndStoreConfigChecksum();
   }
   else {
     Serial.println(F("Error: NTP server name must be less than 32 characters in length"));
-  }  
+  }
 }
 
 void backup(char * arg) {
   if(!configMemoryUnlocked(__LINE__)){
     return;
   }
-  
+
   boolean valid = true;
   char tmp[32] = {0};
   uint16_t backup_check = eeprom_read_word((const uint16_t *) EEPROM_BACKUP_CHECK);
@@ -3442,7 +3442,7 @@ void backup(char * arg) {
       CLEAR_BIT(backup_check, BACKUP_STATUS_TEMPERATURE_CALIBRATION_BIT);
       eeprom_write_word((uint16_t *) EEPROM_BACKUP_CHECK, backup_check);
     }
-  }  
+  }
   else if (strncmp("hum", arg, 3) == 0) {
     eeprom_read_block(tmp, (const void *) EEPROM_HUMIDITY_OFFSET, 4);
     eeprom_write_block(tmp, (void *) EEPROM_BACKUP_HUMIDITY_OFFSET, 4);
@@ -3451,7 +3451,7 @@ void backup(char * arg) {
       CLEAR_BIT(backup_check, BACKUP_STATUS_HUMIDITY_CALIBRATION_BIT);
       eeprom_write_word((uint16_t *) EEPROM_BACKUP_CHECK, backup_check);
     }
-  }  
+  }
   else if (strncmp("tz", arg, 2) == 0) {
     eeprom_read_block(tmp, (const void *) EEPROM_NTP_TZ_OFFSET_HRS, 4);
     eeprom_write_block(tmp, (void *) EEPROM_BACKUP_NTP_TZ_OFFSET_HRS, 4);
@@ -3460,14 +3460,14 @@ void backup(char * arg) {
       CLEAR_BIT(backup_check, BACKUP_STATUS_TIMEZONE_CALIBRATION_BIT);
       eeprom_write_word((uint16_t *) EEPROM_BACKUP_CHECK, backup_check);
     }
-  }    
+  }
   else if (strncmp("all", arg, 3) == 0) {
     valid = false;
     configInject("backup mqttpwd\r");
     configInject("backup key\r");
-    configInject("backup co2\r");    
+    configInject("backup co2\r");
     configInject("backup temp\r");
-    configInject("backup hum\r");    
+    configInject("backup hum\r");
     configInject("backup mac\r");
     configInject("backup tz\r");
     Serial.println();
@@ -3499,8 +3499,8 @@ void set_float_param(char * arg, float * eeprom_address, float (*conversion)(flo
   }
 
   // read the value at that address from eeprom
-  float current_value = eeprom_read_float((const float *) eeprom_address);  
-  
+  float current_value = eeprom_read_float((const float *) eeprom_address);
+
   float value = 0.0;
   if (convertStringToFloat(arg, &value)) {
     if (conversion) {
@@ -3539,7 +3539,7 @@ void set_private_key(char * arg) {
   if(!configMemoryUnlocked(__LINE__)){
     return;
   }
-  
+
   // we've reserved 32-bytes of EEPROM for a private key
   // only exact 64-character hex representation is accepted
   uint8_t key[32] = {0};
@@ -3576,7 +3576,7 @@ void recomputeAndStoreConfigChecksum(void) {
   if(!configMemoryUnlocked(__LINE__)){
     return;
   }
-  
+
   uint16_t crc = computeEepromChecksum();
   eeprom_write_word((uint16_t *) EEPROM_CRC_CHECKSUM, crc);
 }
@@ -3595,14 +3595,14 @@ uint16_t computeEepromChecksum(void) {
 }
 
 uint16_t getStoredEepromChecksum(void){
-  return eeprom_read_word((const uint16_t *) EEPROM_CRC_CHECKSUM);  
+  return eeprom_read_word((const uint16_t *) EEPROM_CRC_CHECKSUM);
 }
 
 uint16_t computeFlashChecksum(void) {
   uint16_t crc = 0;
   // there are EEPROM_CONFIG_MEMORY_SIZE - 2 bytes to compute the CRC16 over
   // the first byte is located at SECOND_TO_LAST_4K_PAGE_ADDRESS + 2
-  // the last byte is located at EEPROM_CONFIG_MEMORY_SIZE - 1  
+  // the last byte is located at EEPROM_CONFIG_MEMORY_SIZE - 1
   for (uint16_t ii = 0; ii < EEPROM_CONFIG_MEMORY_SIZE - 2; ii++) {
     uint8_t value = flash.readByte(((uint32_t) SECOND_TO_LAST_4K_PAGE_ADDRESS) + 2UL + ((uint32_t) ii));
     crc = _crc16_update(crc, value);
@@ -3625,22 +3625,22 @@ void selectNoSlot(void) {
 
 void selectSlot3(void){
   selectNoSlot();
-  digitalWrite(7, HIGH); 
+  digitalWrite(7, HIGH);
 }
 
 boolean add_baseline_voltage_characterization(char * arg, uint32_t eeprom_table_base_address){
   // there should be three values provided
-  // a temperature in degC        [float]  
+  // a temperature in degC        [float]
   // a slope in Volts / degC      [float]
   // an intercept in Volts        [float]
   // tokenization should already be in progress when this function is called
-  
-  char * token = strtok(NULL, " "); // advance to the next token  
+
+  char * token = strtok(NULL, " "); // advance to the next token
   if(token == NULL){
     Serial.println(F("Error: No temperature provided"));
-    return false;  
+    return false;
   }
-    
+
   if (!convertStringToFloat(token, &(baseline_voltage_struct.temperature_degC))) {
     Serial.print(F("Error: Failed to convert temperature string \""));
     Serial.print(token);
@@ -3648,12 +3648,12 @@ boolean add_baseline_voltage_characterization(char * arg, uint32_t eeprom_table_
     return false;
   }
 
-  token = strtok(NULL, " "); // advance to the next token  
+  token = strtok(NULL, " "); // advance to the next token
   if(token == NULL){
     Serial.println(F("Error: No slope provided"));
-    return false;  
+    return false;
   }
-  
+
   if (!convertStringToFloat(token, &(baseline_voltage_struct.slope_volts_per_degC))) {
     Serial.print(F("Error: Failed to convert slope string \""));
     Serial.print(token);
@@ -3662,29 +3662,29 @@ boolean add_baseline_voltage_characterization(char * arg, uint32_t eeprom_table_
   }
 
 
-  token = strtok(NULL, " "); // advance to the next token  
+  token = strtok(NULL, " "); // advance to the next token
   if(token == NULL){
     Serial.println(F("Error: No intercpet provided"));
-    return false;  
-  }  
-  
+    return false;
+  }
+
   if (!convertStringToFloat(token, &(baseline_voltage_struct.intercept_volts))) {
     Serial.print(F("Error: Failed to convert intercept string \""));
     Serial.print(token);
     Serial.println(F("\" to decimal number."));
     return false;
-  }  
+  }
 
   // if you got this far, you've managed to parse three numbers and save them to the temp struct
   // and we should commit the results to EEPROM, and we should do so at the first available
-  // index where the temperature is currently NaN, if there are no such spaces then report an 
+  // index where the temperature is currently NaN, if there are no such spaces then report an
   // error instructing the user to clear the table because it's full
   baseline_voltage_t tmp;
 
   // keep track of the highest temperature we've seen until we find an empty slot
   // and enforce the constraint that the temperature's in the table are monotonically increasing
   // any large negative number would do to initialize, but this is as cold as it gets, because Physics
-  float temperature_of_first_valid_entry_degC = -273.15; 
+  float temperature_of_first_valid_entry_degC = -273.15;
   boolean empty_location_found = false;
   for(uint8_t ii = 0; ii < 5; ii++){
     eeprom_read_block((void *) &tmp, (void *) (eeprom_table_base_address + (ii*sizeof(baseline_voltage_t))), sizeof(baseline_voltage_t));
@@ -3707,7 +3707,7 @@ boolean add_baseline_voltage_characterization(char * arg, uint32_t eeprom_table_
   }
 
   if(!empty_location_found){
-    Serial.print(F("Error: Table is full, please run '"));             
+    Serial.print(F("Error: Table is full, please run '"));
     if(eeprom_table_base_address == EEPROM_CO2_BASELINE_VOLTAGE_TABLE){
       Serial.print(F("co2"));
     }
@@ -3717,7 +3717,7 @@ boolean add_baseline_voltage_characterization(char * arg, uint32_t eeprom_table_
   }
 
   return true;
-  
+
 }
 
 boolean clear_baseline_voltage_characterization(uint32_t eeprom_table_base_address){
@@ -3730,7 +3730,7 @@ boolean clear_baseline_voltage_characterization(uint32_t eeprom_table_base_addre
       deleted_at_least_one_entry = true;
       tmp.temperature_degC = *((float *) (&erase_float));
       tmp.slope_volts_per_degC = *((float *) (&erase_float));
-      tmp.intercept_volts = *((float *) (&erase_float));     
+      tmp.intercept_volts = *((float *) (&erase_float));
       eeprom_write_block((const void *) &tmp, (void *) (eeprom_table_base_address + (ii*sizeof(baseline_voltage_t))), sizeof(baseline_voltage_t));
     }
   }
@@ -3742,8 +3742,8 @@ boolean clear_baseline_voltage_characterization(uint32_t eeprom_table_base_addre
 }
 
 void baseline_voltage_characterization_command(char * arg, uint32_t eeprom_table_base_address){
-  boolean valid = true;  
-  
+  boolean valid = true;
+
   if(!configMemoryUnlocked(__LINE__)){
     return;
   }
@@ -3755,7 +3755,7 @@ void baseline_voltage_characterization_command(char * arg, uint32_t eeprom_table
   char * token = strtok(arg, " "); // tokenize the string on spaces
   if(token == NULL){
     Serial.println(F("Error: no arguments provided"));
-    return;  
+    return;
   }
 
   // the first argument should be either "add", "show", or "clear"
@@ -3775,10 +3775,10 @@ void baseline_voltage_characterization_command(char * arg, uint32_t eeprom_table
     Serial.println("'");
     return;
   }
-  
+
   if (valid) {
     recomputeAndStoreConfigChecksum();
-  }    
+  }
 }
 
 void co2_baseline_voltage_characterization_command(char * arg){
@@ -3786,21 +3786,21 @@ void co2_baseline_voltage_characterization_command(char * arg){
 }
 
 void load_temperature_characterization_entry(uint32_t eeprom_table_base_address, uint8_t index){
-  eeprom_read_block((void *) &baseline_voltage_struct, (void *) (eeprom_table_base_address + (index*sizeof(baseline_voltage_t))), sizeof(baseline_voltage_t));  
+  eeprom_read_block((void *) &baseline_voltage_struct, (void *) (eeprom_table_base_address + (index*sizeof(baseline_voltage_t))), sizeof(baseline_voltage_t));
 }
 
 boolean load_and_validate_temperature_characterization_entry(uint32_t eeprom_table_base_address, uint8_t index){
   return valid_temperature_characterization_entry(eeprom_table_base_address, index);
 }
 
-boolean find_and_load_temperature_characterization_entry(uint32_t eeprom_table_base_address, float target_temperature_degC){  
+boolean find_and_load_temperature_characterization_entry(uint32_t eeprom_table_base_address, float target_temperature_degC){
   // this search requires that table entries are monotonically increasing in temperature
   // which is to say entry[0].temperature_degC < entry[1].temperature_degC < ... < entry[4].temperature_degC
   // this is enforced by the add entry mechanism
 
   // finds the first entry that has a temperature that is <= target_temperature
   // as a side-effect, if such an entry is found, it is loaded into baseline_voltage_struct
-  
+
   int8_t index_of_highest_temperature_that_is_less_than_or_equal_to_target_temperature = -1;
   for(uint8_t ii = 0; ii < 5; ii++){
     if(load_and_validate_temperature_characterization_entry(eeprom_table_base_address, ii)){
@@ -3810,30 +3810,30 @@ boolean find_and_load_temperature_characterization_entry(uint32_t eeprom_table_b
       else{
         break;
       }
-    }    
+    }
   }
 
   if(index_of_highest_temperature_that_is_less_than_or_equal_to_target_temperature >= 0){
-    load_and_validate_temperature_characterization_entry(eeprom_table_base_address, 
+    load_and_validate_temperature_characterization_entry(eeprom_table_base_address,
       index_of_highest_temperature_that_is_less_than_or_equal_to_target_temperature);
-    return true;  
+    return true;
   }
 
   // if we got to here it means that the target temperature is colder than the coldest characterized value
-  // or there are no valid entries 
-  return false; 
-  
+  // or there are no valid entries
+  return false;
+
 }
 
 boolean valid_temperature_characterization_struct(baseline_voltage_t * temperature_characterization_struct_p){
   if(isnan(temperature_characterization_struct_p->temperature_degC)){
     return false;
   }
-  
+
   if(isnan(temperature_characterization_struct_p->slope_volts_per_degC)){
     return false;
   }
-  
+
   if(isnan(temperature_characterization_struct_p->intercept_volts)){
     return false;
   }
@@ -3845,13 +3845,13 @@ boolean valid_temperature_characterization_struct(baseline_voltage_t * temperatu
   if(temperature_characterization_struct_p->temperature_degC > 60.0){
     return false;
   }
-  
-  return true;  
+
+  return true;
 }
 
 boolean valid_temperature_characterization_entry(uint32_t eeprom_table_base_address, uint8_t index){
   // the entry is valid only if none of the three fields are NaN
-  // read the requested table entry into RAM, note side effect is baseline_voltage_struct is loaded with the data    
+  // read the requested table entry into RAM, note side effect is baseline_voltage_struct is loaded with the data
   load_temperature_characterization_entry(eeprom_table_base_address, index);
   return valid_temperature_characterization_struct(&baseline_voltage_struct);
 }
@@ -3864,10 +3864,10 @@ boolean valid_temperature_characterization(uint32_t eeprom_table_base_address){
   return false;
 }
 
-void print_baseline_voltage_characterization_entry(uint32_t eeprom_table_base_address, uint8_t index){ 
-  
+void print_baseline_voltage_characterization_entry(uint32_t eeprom_table_base_address, uint8_t index){
+
   if(valid_temperature_characterization_entry(eeprom_table_base_address, index)){
-    Serial.print(F("        ")); 
+    Serial.print(F("        "));
     Serial.print(index);
     Serial.print(F("\t"));
     Serial.print(baseline_voltage_struct.temperature_degC,8);
@@ -3877,17 +3877,17 @@ void print_baseline_voltage_characterization_entry(uint32_t eeprom_table_base_ad
     Serial.print(baseline_voltage_struct.intercept_volts,8);
     Serial.println();
   }
-  
+
 }
 
 void print_baseline_voltage_characterization(uint32_t eeprom_table_base_address){
-  Serial.print(F("        ")); 
+  Serial.print(F("        "));
   Serial.println(F("idx\ttemp [degC]\tslope [V/degC]\tintercept [V]"));
-  Serial.print(F("        ")); 
+  Serial.print(F("        "));
   Serial.println(F("---------------------------------------------------------"));
   if(!load_and_validate_temperature_characterization_entry(eeprom_table_base_address, 0)){
-    Serial.print(F("        "));   
-    Serial.println(F("No valid entries found.")); 
+    Serial.print(F("        "));
+    Serial.println(F("No valid entries found."));
   }
   else{
     for(uint8_t ii = 0; ii < 5; ii++){
@@ -3906,7 +3906,7 @@ void safe_dtostrf(float value, signed char width, unsigned char precision, char 
   char meta_format_string[16] = "%%.%df";
   char format_string[16] = {0};
 
-  if((target_buffer != NULL) && (target_buffer_length > 0)){  
+  if((target_buffer != NULL) && (target_buffer_length > 0)){
     snprintf(format_string, 15, meta_format_string, precision); // format string should come out to something like "%.2f"
     snprintf(target_buffer, target_buffer_length - 1, format_string, value);
   }
@@ -3932,32 +3932,32 @@ void backlightOff(void) {
 void lcdFrownie(uint8_t pos_x, uint8_t pos_y){
   if((pos_x < 16) && (pos_y < 2)){
     lcd.setCursor(pos_x, pos_y);
-    lcd.write((byte) 1); 
+    lcd.write((byte) 1);
   }
 }
 
 void lcdSmiley(uint8_t pos_x, uint8_t pos_y){
   if((pos_x < 16) && (pos_y < 2)){
     lcd.setCursor(pos_x, pos_y);
-    lcd.write((byte) 0); 
+    lcd.write((byte) 0);
   }
 }
 
-void lcdBars(uint8_t numBars){  
+void lcdBars(uint8_t numBars){
   for(uint8_t ii = 0; ii < numBars && ii < 5; ii++){
     lcd.setCursor(5+ii, 1);
     lcd.write(3); // full bar
   }
-  
+
   if(numBars < 5){
     for(uint8_t ii = 0; ii <  5 - numBars; ii++){
-      lcd.setCursor(5 + numBars + ii, 1); 
+      lcd.setCursor(5 + numBars + ii, 1);
       lcd.write((byte) 2); // empty bar
     }
   }
 }
 
-void setLCD_P(const char * str PROGMEM){  
+void setLCD_P(const char * str PROGMEM){
   char tmp[33] = {0};
   strncpy_P(tmp, str, 32);
   setLCD(tmp);
@@ -3971,7 +3971,7 @@ void setLCD_P(const char * str PROGMEM){
 //    if(ii != 16){
 //      Serial.print(F(","));
 //    }
-//  } 
+//  }
 //  Serial.println();
 //  Serial.print(F("Debug: Line 2: "));
 //  for(uint8_t ii = 0; ii < 17; ii++){
@@ -3981,20 +3981,20 @@ void setLCD_P(const char * str PROGMEM){
 //      Serial.print(F(","));
 //    }
 //  }
-//  Serial.println();  
+//  Serial.println();
 //}
 
 void repaintLCD(void){
-  //dumpDisplayBuffer();      
+  //dumpDisplayBuffer();
   //  if(strlen((char *) &(g_lcd_buffer[0])) <= 16){
-  //    lcd.setCursor(0,0);    
+  //    lcd.setCursor(0,0);
   //    lcd.print((char *) &(g_lcd_buffer[0]));
   //  }
-  //  
+  //
   //  if(strlen((char *) &(g_lcd_buffer[1])) <= 16){
-  //    lcd.setCursor(0,1);    
-  //    lcd.print((char *) &(g_lcd_buffer[1])); 
-  //  }    
+  //    lcd.setCursor(0,1);
+  //    lcd.print((char *) &(g_lcd_buffer[1]));
+  //  }
 
   char tmp[2] = " ";
   for(uint8_t line = 0; line < 2; line++){
@@ -4005,20 +4005,20 @@ void repaintLCD(void){
         lcd.print(tmp);
       }
       last_painted[line][column] = g_lcd_buffer[line][column];
-    } 
-  }  
-  
+    }
+  }
+
   g_lcd_buffer[0][16] = '\0'; // ensure null termination
-  g_lcd_buffer[1][16] = '\0'; // ensure null termination  
+  g_lcd_buffer[1][16] = '\0'; // ensure null termination
 }
 
 void setLCD(const char * str){
   clearLCD();
-  uint16_t original_length = strlen(str);  
-  strncpy((char *) &(g_lcd_buffer[0]), str, 16);  
-  if(original_length > 16){   
-    strncpy((char *) &(g_lcd_buffer[1]), str + 16, 16);    
-  }   
+  uint16_t original_length = strlen(str);
+  strncpy((char *) &(g_lcd_buffer[0]), str, 16);
+  if(original_length > 16){
+    strncpy((char *) &(g_lcd_buffer[1]), str + 16, 16);
+  }
   repaintLCD();
 }
 
@@ -4030,21 +4030,21 @@ void updateLCD(const char * str, uint8_t pos_x, uint8_t pos_y, uint8_t num_chars
   uint16_t len = strlen(str);
   char * ptr = 0;
   if((pos_y == 0) || (pos_y == 1)){
-    ptr = (char *) &(g_lcd_buffer[pos_y]);   
+    ptr = (char *) &(g_lcd_buffer[pos_y]);
   }
-  
+
   uint8_t x = 0;  // display buffer index
   uint8_t ii = 0; // input string index
   for(x = pos_x, ii = 0;  (x < 16) && (ii < len) && (ii < num_chars); x++, ii++){
     // don't allow the injection of non-printable characters into the display buffer
-    if(isprint(str[ii])){    
+    if(isprint(str[ii])){
       ptr[x] = str[ii];
     }
     else{
       ptr[x] = ' ';
     }
   }
-  
+
   if(repaint){
     repaintLCD();
   }
@@ -4059,12 +4059,12 @@ void clearLCD(boolean repaint){
   memset((uint8_t *) &(g_lcd_buffer[1]), ' ', 16);
   memset((uint8_t *) &(last_painted[0]), ' ', 16);
   memset((uint8_t *) &(last_painted[1]), ' ', 16);
-        
+
   g_lcd_buffer[0][16] = '\0';
-  g_lcd_buffer[1][16] = '\0';  
+  g_lcd_buffer[1][16] = '\0';
   last_painted[0][16] = '\0';
-  last_painted[1][16] = '\0';      
-          
+  last_painted[1][16] = '\0';
+
   lcd.clear();
   if(repaint){
     repaintLCD();
@@ -4076,10 +4076,10 @@ boolean index_of(char ch, char * str, uint16_t * index){
   for(uint16_t ii = 0; ii < len; ii++){
     if(str[ii] == ch){
       *index = ii;
-      return true;     
+      return true;
     }
   }
-  
+
   return false;
 }
 
@@ -4088,11 +4088,11 @@ void ltrim_string(char * str){
   uint16_t len = strlen(str);
   for(uint16_t ii = 0; ii < len; ii++){
     if(!isspace(str[ii])){
-      break;      
-    }     
+      break;
+    }
     num_leading_spaces++;
   }
-  
+
   if(num_leading_spaces > 0){
     // copy the string left, including the null terminator
     // which is why this loop is <= len
@@ -4107,7 +4107,7 @@ void rtrim_string(char * str){
   // overwrite space characters with null characteres
   // until you reach a non-space character
   // or you overwrite the entire string
-  int16_t ii = strlen(str) - 1;  
+  int16_t ii = strlen(str) - 1;
   while(ii >= 0){
     if(isspace(str[ii])){
       str[ii] = '\0';
@@ -4121,18 +4121,18 @@ void rtrim_string(char * str){
 
 void trim_string(char * str){
   ltrim_string(str);
-  
+
   //Serial.print(F("ltrim: "));
   //Serial.println(str);
-  
+
   rtrim_string(str);
-  
+
   //Serial.print(F("rtrim: "));
-  //Serial.println(str);  
+  //Serial.println(str);
 }
 
 void replace_nan_with_null(char * str){
-  if(strcmp(str, "nan") == 0){    
+  if(strcmp(str, "nan") == 0){
     strcpy(str, "null");
   }
 }
@@ -4155,27 +4155,27 @@ boolean truncate_float_string(char * str, uint8_t field_width){
   // examples for field_width := 3
   //             v-- field boundardy (for field_width := 3)
   // Case 0:  0.3|4  is ok (and will be truncated to 0.3)
-  // Case 0b: 0. |   is ok (and will be truncated to 0)    
-  // Case 0c: -0.|3  is ok (and will be truncated to 0)            
+  // Case 0b: 0. |   is ok (and will be truncated to 0)
+  // Case 0c: -0.|3  is ok (and will be truncated to 0)
   // Case 1:  1.2|4  is ok (and will be truncated to 1.2)
   // Case 1b: 1. |   is ok (and will be truncated to 1)
   // Case 1c: 1  |   is ok (and will be truncated to 1)
-  // Case 2b: 12.|5  is ok (and will be truncated to 13)  
+  // Case 2b: 12.|5  is ok (and will be truncated to 13)
   // Cas3 2c: 12.|   is ok (and will be truncated to 12)
-  // Cas3 2d: 12 |   is ok (and will be truncated to 12)  
+  // Cas3 2d: 12 |   is ok (and will be truncated to 12)
   // Case 3:  123|.4 is ok (and will be truncated to 123)
   // Case 3b: 123|.  is ok (and will be truncated to 123)
   // Case 3c: 123|   is ok (and will be truncated to 123)
-  // Case 3d: -12|3  is not ok (because it would be truncated to -12)  
-  // Case 3f: -12|3. is not ok (because it would be truncated to -12)  
+  // Case 3d: -12|3  is not ok (because it would be truncated to -12)
+  // Case 3f: -12|3. is not ok (because it would be truncated to -12)
   // Case 4:  123|4  is not ok (because it would be truncated to 123)
   // Case 4b: 123|4. is not ok (because it would be truncated to 123)
   //          012|345678901234567 (index for reference)
-  
+
   uint16_t period_index = 0;
 
   // first trim the string to remove leading and trailing ' ' characters
-  trim_string(str);  
+  trim_string(str);
 
   uint16_t len = strlen(str);
   boolean string_contains_decimal_point = index_of('.', str, &period_index);
@@ -4188,13 +4188,13 @@ boolean truncate_float_string(char * str, uint8_t field_width){
   //Serial.print(string_contains_decimal_point);
   //Serial.print(F(", period_index = "));
   //Serial.println(period_index);
-  
-  if(len > field_width){   
+
+  if(len > field_width){
     if(string_contains_decimal_point){
       // there's a decimal point in the string somewhere
       // and the string is longer than the field width
       if(period_index > field_width){
-        // the decimal point occurs at least 
+        // the decimal point occurs at least
         // two characters past the field boundary
         return false;
       }
@@ -4203,33 +4203,33 @@ boolean truncate_float_string(char * str, uint8_t field_width){
       // it's a pure whole number
       // and there's not enough room in the field to hold it
       return false;
-    }            
-  } 
-  
+    }
+  }
+
   // first truncate the string to the field width if it's longer than the field width
   if(len > field_width){
     str[field_width] = '\0';
     //Serial.print(F("truncated step 1: "));
     //Serial.println(str);
   }
-  
+
   len = strlen(str);
   // if the last character in the string is a decimal point, lop it off
   if((len > 0) && (str[len-1] == '.')){
      str[len-1] = '\0';
      //Serial.print(F("truncated step 2:"));
      //Serial.println(str);
-  }    
-      
+  }
+
   // it's already adequately truncated if len <= field_width
   return true;
 }
 
 // the caller must ensure that there is adequate memory
-// allocated to str, so that it can be safely padded 
+// allocated to str, so that it can be safely padded
 // to target length
 void leftpad_string(char * str, uint16_t target_length){
-  uint16_t len = strlen(str);  
+  uint16_t len = strlen(str);
   if(len < target_length){
     uint16_t pad_amount = target_length - len;
 
@@ -4238,9 +4238,9 @@ void leftpad_string(char * str, uint16_t target_length){
     // and copying characters over (copying the null terminator is why it starts at len)
     for(int16_t ii = len; ii >= 0; ii--){
       str[ii + pad_amount] = str[ii];
-    } 
-    
-    // then put spaces in the front 
+    }
+
+    // then put spaces in the front
     for(uint16_t ii = 0; ii < pad_amount; ii++){
       str[ii] = ' ';
     }
@@ -4256,62 +4256,62 @@ void updateLCD(float value, uint8_t pos_x, uint8_t pos_y, uint8_t field_width, b
   static char asterisks_field[17] = {0};
   memset(tmp, 0, 64);
   memset(asterisks_field, 0, 17);
-  
+
   for(uint8_t ii = 0; (ii < field_width) && (ii < 16); ii++){
-     asterisks_field[ii] = '*'; 
-  }  
-  
+     asterisks_field[ii] = '*';
+  }
+
   //Serial.print(F("value: "));
-  //Serial.println(value,8);  
-  
+  //Serial.println(value,8);
+
   safe_dtostrf(value, -16, 6, tmp, 16);
-  
+
   //Serial.print(F("dtostrf: "));
   //Serial.println(tmp);
-  
+
   if(!truncate_float_string(tmp, field_width)){
     updateLCD(asterisks_field, pos_x, pos_y, field_width);
     return;
   }
-  
+
   //Serial.print(F("truncate: "));
   //Serial.println(tmp);
-  
-  leftpad_string(tmp, field_width); 
+
+  leftpad_string(tmp, field_width);
   //Serial.print(F("leftpad_string: "));
   //Serial.println(tmp);
-      
-  updateLCD(tmp, pos_x, pos_y, field_width, repaint);  
+
+  updateLCD(tmp, pos_x, pos_y, field_width, repaint);
 }
 
 void updateLCD(uint32_t ip, uint8_t line_number){
   char tmp[17] = {0};
-  snprintf(tmp, 16, "%d.%d.%d.%d", 
+  snprintf(tmp, 16, "%d.%d.%d.%d",
     (uint8_t)(ip >> 24),
     (uint8_t)(ip >> 16),
-    (uint8_t)(ip >> 8),       
-    (uint8_t)(ip >> 0));    
-  
+    (uint8_t)(ip >> 8),
+    (uint8_t)(ip >> 0));
+
   updateLCD(tmp, line_number);
 }
 
 void updateLCD(const char * str, uint8_t line_number){
   // center the string on the line
-  char tmp[17] = {0};  
+  char tmp[17] = {0};
   uint16_t original_len = strlen(str);
   if(original_len < 16){
     uint8_t num_empty_chars_on_line = 16 - original_len;
     // pad the front of the string with spaces
     uint8_t half_num_empty_chars_on_line = num_empty_chars_on_line / 2;
     for(uint8_t ii = 0; ii < half_num_empty_chars_on_line; ii++){
-      tmp[ii] = ' '; 
-    }    
+      tmp[ii] = ' ';
+    }
   }
-  uint16_t len = strlen(tmp);  // length of the front padding    
+  uint16_t len = strlen(tmp);  // length of the front padding
   if((original_len + len) <= 16){
     strcat(tmp, str); // concatenate the string into the front padding-
   }
-  
+
   len = strlen(tmp);
   if(len < 16){
     // pad the tail of the string with spaces
@@ -4320,7 +4320,7 @@ void updateLCD(const char * str, uint8_t line_number){
       tmp[len + ii] = ' ';
     }
   }
-  
+
   if(line_number < 2){
     updateLCD(tmp, 0, line_number, 16);
   }
@@ -4343,9 +4343,9 @@ void updateCornerDot(void){
   on = 1 - on;
   if(on == 1){
     updateLCD('.', 15, 1, 1);
-  } 
+  }
   else{
-    updateLCD(' ', 15, 1, 1); 
+    updateLCD(' ', 15, 1, 1);
   }
 }
 
@@ -4354,39 +4354,39 @@ void updateLcdProgressDots(void){
   cnt++;
   uint8_t num_dots = cnt % 4;
   switch(num_dots){
-    case 0: 
-      updateLCD("   ", 1); 
+    case 0:
+      updateLCD("   ", 1);
       break;
     case 1:
-      updateLCD(".  ", 1); 
+      updateLCD(".  ", 1);
       break;
     case 2:
-      updateLCD(".. ", 1); 
+      updateLCD(".. ", 1);
       break;
     case 3:
-      updateLCD("...", 1); 
-      break;          
-  } 
+      updateLCD("...", 1);
+      break;
+  }
 }
 
 /****** WIFI SUPPORT FUNCTIONS ******/
 void displayRSSI(void){
   char ssid[33] = {0};
-  static ap_scan_result_t res = {0};    
+  static ap_scan_result_t res = {0};
   int8_t max_rssi = -256;
   boolean found_ssid = false;
-  uint8_t target_network_secMode = WLAN_SEC_AUTO;  
-  uint8_t network_security_mode = eeprom_read_byte((const uint8_t *) EEPROM_SECURITY_MODE);   
-  uint8_t num_results_found = 0;  
-  
+  uint8_t target_network_secMode = WLAN_SEC_AUTO;
+  uint8_t network_security_mode = eeprom_read_byte((const uint8_t *) EEPROM_SECURITY_MODE);
+  uint8_t num_results_found = 0;
+
   eeprom_read_block(ssid, (const void *) EEPROM_SSID, 32);
-  
+
   setLCD_P(PSTR(" SCANNING WI-FI "
                 "                "));
-  Serial.println(F("Info: Beginning Network Scan..."));                
+  Serial.println(F("Info: Beginning Network Scan..."));
   SUCCESS_MESSAGE_DELAY();
-  
-  boolean foundSSID = false; 
+
+  boolean foundSSID = false;
   uint8_t num_scan_attempts = 0;
   do{
     foundSSID = esp.scanForAccessPoint(ssid, &res, &num_results_found);
@@ -4395,22 +4395,22 @@ void displayRSSI(void){
       delay(100);
     }
   } while(!foundSSID && (num_scan_attempts <= 3));
-  
+
   Serial.print(F("Info: Network Scan found "));
   Serial.print(num_results_found);
   Serial.println(F(" networks"));
-  
+
   Serial.print(F("Info: Access Point \""));
   Serial.print(ssid);
   Serial.print(F("\", "));
   if(foundSSID){
-    target_network_secMode = res.security;    
+    target_network_secMode = res.security;
     Serial.print(F("RSSI = "));
-    Serial.println(res.rssi);    
+    Serial.println(res.rssi);
     int8_t rssi_dbm = res.rssi;
     lcdBars(rssi_to_bars(rssi_dbm));
     lcdSmiley(15, 1); // lower right corner
-    
+
     if(network_security_mode == WLAN_SEC_AUTO){
       allowed_to_write_config_eeprom = true;
       if(target_network_secMode == 0){
@@ -4425,13 +4425,13 @@ void displayRSSI(void){
       else if((target_network_secMode == 3) || (target_network_secMode == 4)){
         set_network_security_mode("wpa2");
       }
-      allowed_to_write_config_eeprom = false;      
+      allowed_to_write_config_eeprom = false;
     }
-    
+
     ERROR_MESSAGE_DELAY(); // ERROR is intentional here, to get a longer delay
   }
   else{
-    Serial.println(F("Not Found.")); 
+    Serial.println(F("Not Found."));
     Serial.println(F("Info: Attempting to connect anyway."));
     updateLCD("NOT FOUND", 1);
     lcdFrownie(15, 1); // lower right corner
@@ -4458,35 +4458,35 @@ uint8_t rssi_to_bars(int8_t rssi_dbm){
   }
   else{
     num_bars = 5;
-  }  
-  
+  }
+
   return num_bars;
 }
 
-boolean restartWifi(){    
-  if(!connectedToNetwork()){        
+boolean restartWifi(){
+  if(!connectedToNetwork()){
     delayForWatchdog();
     petWatchdog();
     current_millis = millis();
     reconnectToAccessPoint();
     current_millis = millis();
     delayForWatchdog();
-    petWatchdog();    
-    acquireIpAddress(); 
+    petWatchdog();
+    acquireIpAddress();
     current_millis = millis();
     delayForWatchdog();
-    petWatchdog();    
+    petWatchdog();
     displayConnectionDetails();
 
     clearLCD();
   }
-  
+
   return connectedToNetwork();
 }
 
 bool displayConnectionDetails(void){
   uint32_t ipAddress, netmask, gateway;
-  
+
   if(!esp.getIPAddress(&ipAddress, &gateway, &netmask))
   {
     Serial.println(F("Error: Unable to retrieve the IP Address!"));
@@ -4495,29 +4495,29 @@ bool displayConnectionDetails(void){
   else
   {
     char ip_str[16] = {0};
-    
-    Serial.print(F("Info: IP Addr: ")); 
+
+    Serial.print(F("Info: IP Addr: "));
     memset(ip_str, 0, 16);
-    esp.IpUint32ToString(ipAddress, &(ip_str[0])); 
+    esp.IpUint32ToString(ipAddress, &(ip_str[0]));
     Serial.print((char *) ip_str);
     Serial.println();
-    
-    Serial.print(F("Info: Netmask: ")); 
+
+    Serial.print(F("Info: Netmask: "));
     memset(ip_str, 0, 16);
-    esp.IpUint32ToString(netmask, &(ip_str[0])); 
+    esp.IpUint32ToString(netmask, &(ip_str[0]));
     Serial.print((char *) ip_str);
     Serial.println();
-    
-    Serial.print(F("Info: Gateway: ")); 
+
+    Serial.print(F("Info: Gateway: "));
     memset(ip_str, 0, 16);
-    esp.IpUint32ToString(gateway, &(ip_str[0])); 
+    esp.IpUint32ToString(gateway, &(ip_str[0]));
     Serial.print((char *) ip_str);
-    Serial.println();    
-    
+    Serial.println();
+
     updateLCD(ipAddress, 1);
     lcdSmiley(15, 1); // lower right corner
-    SUCCESS_MESSAGE_DELAY();  
-  
+    SUCCESS_MESSAGE_DELAY();
+
     return true;
   }
 }
@@ -4532,9 +4532,9 @@ void reconnectToAccessPoint(void){
   if(first_access){
     first_access = false;
     connect_method = eeprom_read_byte((const uint8_t *) EEPROM_CONNECT_METHOD);
-    network_security_mode = eeprom_read_byte((const uint8_t *) EEPROM_SECURITY_MODE);  
+    network_security_mode = eeprom_read_byte((const uint8_t *) EEPROM_SECURITY_MODE);
     eeprom_read_block(ssid, (const void *) EEPROM_SSID, 32);
-    eeprom_read_block(network_password, (const void *) EEPROM_NETWORK_PWD, 31); 
+    eeprom_read_block(network_password, (const void *) EEPROM_NETWORK_PWD, 31);
     eeprom_read_block(mac_address, (const void *) EEPROM_MAC_ADDRESS, 6);
   }
 
@@ -4544,7 +4544,7 @@ void reconnectToAccessPoint(void){
   if (!esp.setMacAddress(mac_address)) {
     Serial.println(F("Error: Failed to write MAC address to ESP8266"));
   }
-  
+
   switch(connect_method){
     case CONNECT_METHOD_DIRECT:
       Serial.print(F("Info: Connecting to Access Point with SSID \""));
@@ -4554,7 +4554,7 @@ void reconnectToAccessPoint(void){
       updateLCD(ssid, 1);
       delayForWatchdog();
       petWatchdog();
-      
+
       if(!esp.connectToNetwork((char *) ssid, (char *) network_password)){
         Serial.print(F("Error: Failed to connect to Access Point with SSID: "));
         Serial.println(ssid);
@@ -4567,7 +4567,7 @@ void reconnectToAccessPoint(void){
 
       // if your configured for static ip address then setStaticIP
       // otherwise setDHCP
-      
+
       Serial.println(F("OK."));
       updateLCD("CONNECTED", 1);
       lcdSmiley(15, 1);
@@ -4576,7 +4576,7 @@ void reconnectToAccessPoint(void){
     default:
       Serial.println(F("Error: Connection method not currently supported"));
       break;
-  }  
+  }
 }
 
 void acquireIpAddress(void){
@@ -4584,7 +4584,7 @@ void acquireIpAddress(void){
   static uint32_t static_ip = 0;
   static uint32_t static_gateway = 0;
   static uint32_t static_netmask = 0;
-  
+
   uint8_t noip[4] = {0};
 
   if(first_access){
@@ -4597,35 +4597,35 @@ void acquireIpAddress(void){
     eeprom_read_block(ip, (const void *) EEPROM_STATIC_GATEWAY, 4);
     static_gateway = esp.IpArrayToIpUint32((uint8_t *) &(ip[0]));
   }
-  
+
   // if it's DHCP we're configured for, engage DHCP process
   if (static_ip == 0){
     /* Wait for DHCP to complete */
     Serial.print(F("Info: Request DHCP..."));
-    setLCD_P(PSTR(" REQUESTING IP  "));   
-    
+    setLCD_P(PSTR(" REQUESTING IP  "));
+
     const long dhcp_timeout_duration_ms = 60000L;
     unsigned long previous_dhcp_timeout_millis = current_millis;
     uint32_t ii = 0;
     if(esp.setDHCP()){
-      Serial.println(F("OK.")); 
-    }        
+      Serial.println(F("OK."));
+    }
     else{
         Serial.println(F("Error: Failed to acquire IP address via DHCP. Rebooting."));
         Serial.flush();
         updateLCD("FAILED", 1);
         lcdFrownie(15, 1);
-        ERROR_MESSAGE_DELAY();    
+        ERROR_MESSAGE_DELAY();
         watchdogForceReset();
-      }      
-    }   
+      }
+    }
     else{
       Serial.print(F("Info: Setting Static IP configuration..."));
       if(!esp.setStaticIPAddress(static_ip, static_netmask, static_gateway, 0)){
-        Serial.println(F("Failed.")); 
+        Serial.println(F("Failed."));
       }
       else{
-      Serial.println(F("OK.")); 
+      Serial.println(F("OK."));
     }
   }
 }
@@ -4644,9 +4644,9 @@ void espIpToArray(uint32_t ip, uint8_t * ip_array){
 uint32_t arrayToESP8266Ip(uint8_t * ip_array){
   uint32_t ip = 0;
   for(int8_t ii = 3; ii > 0; ii++){
-    ip |= ip_array[ii];    
+    ip |= ip_array[ii];
     ip <<= 8;
-  }  
+  }
   return ip;
 }
 
@@ -4655,16 +4655,16 @@ uint32_t arrayToESP8266Ip(uint8_t * ip_array){
 // 62.5 microvolts resolution in 16-bit mode
 boolean burstSampleADC(int adcChannel, float * result){
   #define NUM_SAMPLES_PER_BURST (8)
-  
-  int32_t burst_sample_total = 0;  
+
+  int32_t burst_sample_total = 0;
   int32_t value = 0;
-  for(uint8_t ii = 0; ii < NUM_SAMPLES_PER_BURST; ii++){        
+  for(uint8_t ii = 0; ii < NUM_SAMPLES_PER_BURST; ii++){
     value = analogRead(adcChannel);
     burst_sample_total += value;
   }
   const float adc_resolution_volts_per_lsb = (5.0f / 1024.0f);
-  *result = (adc_resolution_volts_per_lsb * burst_sample_total) / NUM_SAMPLES_PER_BURST;  
-  
+  *result = (adc_resolution_volts_per_lsb * burst_sample_total) / NUM_SAMPLES_PER_BURST;
+
   return true;
 }
 
@@ -4672,48 +4672,48 @@ boolean burstSampleADC(int adcChannel, float * result){
 void clearTempBuffers(void){
   memset(converted_value_string, 0, 64);
   memset(compensated_value_string, 0, 64);
-  memset(raw_instant_value_string, 0, 64);  
+  memset(raw_instant_value_string, 0, 64);
   memset(raw_value_string, 0, 64);
   memset(scratch, 0, SCRATCH_BUFFER_SIZE);
   scratch_idx = 0;
   memset(MQTT_TOPIC_STRING, 0, 128);
-  memset(response_body, 0, 256); 
+  memset(response_body, 0, 256);
 }
 
 boolean mqttResolve(void){
   uint32_t ip = 0;
   static boolean resolved = false;
-  
+
   char mqtt_server_name[32] = {0};
   if(!resolved){
     eeprom_read_block(mqtt_server_name, (const void *) EEPROM_MQTT_SERVER_NAME, 31);
     setLCD_P(PSTR("   RESOLVING"));
     updateLCD("MQTT SERVER", 1);
     SUCCESS_MESSAGE_DELAY();
-    if  (!esp.getHostByName(mqtt_server_name, &ip) || (ip == 0))  {      
+    if  (!esp.getHostByName(mqtt_server_name, &ip) || (ip == 0))  {
       Serial.print(F("Error: Couldn't resolve '"));
       Serial.print(mqtt_server_name);
       Serial.println(F("'"));
-      
+
       updateLCD("FAILED", 1);
       lcdFrownie(15, 1);
       ERROR_MESSAGE_DELAY();
       return false;
-    }  
+    }
     else{
       resolved = true;
-      espIpToArray(ip, mqtt_server_ip);      
+      espIpToArray(ip, mqtt_server_ip);
       Serial.print(F("Info: Resolved \""));
       Serial.print(mqtt_server_name);
       Serial.print(F("\" to IP address "));
       char ip_str[16] = {0};
       esp.IpUint32ToString(ip, &(ip_str[0]));
       Serial.print((char *) ip_str);
-      
-      updateLCD(ip, 1);      
+
+      updateLCD(ip, 1);
       lcdSmiley(15, 1);
-      SUCCESS_MESSAGE_DELAY();          
-      Serial.println();    
+      SUCCESS_MESSAGE_DELAY();
+      Serial.println();
     }
   }
   return true;
@@ -4725,13 +4725,13 @@ boolean mqttReconnect(void){
    static char mqtt_password[32] = {0};
    static uint8_t mqtt_auth_enabled = 0;
    static uint32_t mqtt_port = 0;
-   
+
    boolean loop_return_flag = true;
-   
+
    if(!mqttResolve()){
      return false;
    }
-     
+
    if(first_access){
      first_access = false;
      loop_return_flag = false;
@@ -4744,12 +4744,12 @@ boolean mqttReconnect(void){
      mqtt_port = eeprom_read_dword((const uint32_t *) EEPROM_MQTT_PORT);
 
      mqtt_client.setServer(mqtt_server_ip, mqtt_port);
-     mqtt_client.setClient(esp);          
+     mqtt_client.setClient(esp);
    }
    else{
      loop_return_flag = mqtt_client.loop();
-   }           
-   
+   }
+
    if(!loop_return_flag){
      Serial.print(F("Info: Connecting to MQTT Broker with Client ID \""));
      Serial.print(mqtt_client_id);
@@ -4764,74 +4764,74 @@ boolean mqttReconnect(void){
        connect_status = mqtt_client.connect(mqtt_client_id);
      }
 
-     clearLCD();         
+     clearLCD();
      if (connect_status) {
        Serial.println(F("OK."));
        return true;
      }
      else{
-       Serial.println(F("Failed.")); 
-       return false;       
-     }    
-   }  
+       Serial.println(F("Failed."));
+       return false;
+     }
+   }
 
    return loop_return_flag;
 }
 
 boolean mqttPublish(char * topic, char *str){
   boolean response_status = true;
-  
+
   Serial.print(F("Info: MQTT publishing to topic "));
   Serial.print(topic);
   Serial.print(F("..."));
-  
+
   uint32_t space_required = 5;
   space_required += strlen(topic);
   space_required += strlen(str);
   if(space_required >= 1023){
     Serial.println(F("Aborted."));
     response_status = false;
-  } 
+  }
   else if(mqtt_client.publish(topic, str)){
     Serial.println(F("OK."));
     response_status = true;
-  } 
+  }
   else {
     Serial.println(F("Failed."));
     response_status = false;
   }
 
   mqtt_client.loop();
-  
+
   return response_status;
 }
 
 
 boolean publishHeartbeat(){
   clearTempBuffers();
-  static uint32_t post_counter = 0;  
+  static uint32_t post_counter = 0;
   uint8_t sample = pgm_read_byte(&heartbeat_waveform[heartbeat_waveform_index++]);
-  
-  snprintf(scratch, SCRATCH_BUFFER_SIZE-1, 
+
+  snprintf(scratch, SCRATCH_BUFFER_SIZE-1,
   "{"
   "\"serial-number\":\"%s\","
   "\"converted-value\":%d,"
   "\"firmware-version\":\"%s\","
   "\"publishes\":[\"co2\",\"temperature\",\"humidity\"],"
   "\"counter\":%lu"
-  "}", mqtt_client_id, sample, firmware_version, post_counter++);  
-  
+  "}", mqtt_client_id, sample, firmware_version, post_counter++);
+
   if(heartbeat_waveform_index >= NUM_HEARTBEAT_WAVEFORM_SAMPLES){
      heartbeat_waveform_index = 0;
   }
-  
+
   replace_character(scratch, '\'', '\"');
-  
+
   strcat(MQTT_TOPIC_STRING, MQTT_TOPIC_PREFIX);
-  strcat(MQTT_TOPIC_STRING, "heartbeat");    
+  strcat(MQTT_TOPIC_STRING, "heartbeat");
   if(mqtt_suffix_enabled){
-    strcat(MQTT_TOPIC_STRING, "/");      
-    strcat(MQTT_TOPIC_STRING, mqtt_client_id);      
+    strcat(MQTT_TOPIC_STRING, "/");
+    strcat(MQTT_TOPIC_STRING, mqtt_client_id);
   }
   return mqttPublish(MQTT_TOPIC_STRING, scratch);
 }
@@ -4842,7 +4842,7 @@ float toFahrenheit(float degC){
 
 boolean publishTemperature(){
   clearTempBuffers();
-  uint16_t num_samples = temperature_ready ? sample_buffer_depth : sample_buffer_idx;  
+  uint16_t num_samples = temperature_ready ? sample_buffer_depth : sample_buffer_idx;
   float temperature_moving_average = calculateAverage(&(sample_buffer[TEMPERATURE_SAMPLE_BUFFER][0]), num_samples);
   temperature_degc = temperature_moving_average;
   float raw_temperature = temperature_degc;
@@ -4857,7 +4857,7 @@ boolean publishTemperature(){
   }
   safe_dtostrf(reported_temperature, -6, 2, converted_value_string, 16);
   safe_dtostrf(raw_temperature, -6, 2, raw_value_string, 16);
-  
+
   trim_string(converted_value_string);
   trim_string(raw_value_string);
   trim_string(raw_instant_value_string);
@@ -4865,7 +4865,7 @@ boolean publishTemperature(){
   replace_nan_with_null(converted_value_string);
   replace_nan_with_null(raw_value_string);
   replace_nan_with_null(raw_instant_value_string);
-  
+
   snprintf(scratch, SCRATCH_BUFFER_SIZE-1,
     "{"
     "\"serial-number\":\"%s\","
@@ -4876,39 +4876,39 @@ boolean publishTemperature(){
     "\"raw-units\":\"deg%c\","
     "\"sensor-part-number\":\"SHT25\""
     "%s"
-    "}", 
-    mqtt_client_id, 
-    converted_value_string, 
-    temperature_units, 
-    raw_value_string, 
+    "}",
+    mqtt_client_id,
+    converted_value_string,
+    temperature_units,
+    raw_value_string,
     raw_instant_value_string,
-    temperature_units, 
+    temperature_units,
     gps_mqtt_string);
 
   replace_character(scratch, '\'', '\"');
-    
+
   strcat(MQTT_TOPIC_STRING, MQTT_TOPIC_PREFIX);
-  strcat(MQTT_TOPIC_STRING, "temperature");    
+  strcat(MQTT_TOPIC_STRING, "temperature");
   if(mqtt_suffix_enabled){
-    strcat(MQTT_TOPIC_STRING, "/");      
-    strcat(MQTT_TOPIC_STRING, mqtt_client_id);      
+    strcat(MQTT_TOPIC_STRING, "/");
+    strcat(MQTT_TOPIC_STRING, mqtt_client_id);
   }
-       
+
   return mqttPublish(MQTT_TOPIC_STRING, scratch);
 }
 
 boolean publishHumidity(){
   clearTempBuffers();
-  uint16_t num_samples = humidity_ready ? sample_buffer_depth : sample_buffer_idx;  
+  uint16_t num_samples = humidity_ready ? sample_buffer_depth : sample_buffer_idx;
   float humidity_moving_average = calculateAverage(&(sample_buffer[HUMIDITY_SAMPLE_BUFFER][0]), num_samples);
   relative_humidity_percent = humidity_moving_average;
   float raw_humidity = constrain(relative_humidity_percent, 0.0f, 100.0f);
   float reported_humidity = constrain(relative_humidity_percent - reported_humidity_offset_percent, 0.0f, 100.0f);
-  
+
   safe_dtostrf(reported_humidity, -6, 2, converted_value_string, 16);
   safe_dtostrf(raw_humidity, -6, 2, raw_value_string, 16);
   safe_dtostrf(instant_humidity_percent, -6, 2, raw_instant_value_string, 16);
-  
+
   trim_string(converted_value_string);
   trim_string(raw_value_string);
   trim_string(raw_instant_value_string);
@@ -4916,39 +4916,39 @@ boolean publishHumidity(){
   replace_nan_with_null(converted_value_string);
   replace_nan_with_null(raw_value_string);
   replace_nan_with_null(raw_instant_value_string);
-  
-  snprintf(scratch, SCRATCH_BUFFER_SIZE-1, 
+
+  snprintf(scratch, SCRATCH_BUFFER_SIZE-1,
     "{"
-    "\"serial-number\":\"%s\","    
+    "\"serial-number\":\"%s\","
     "\"converted-value\":%s,"
     "\"converted-units\":\"percent\","
     "\"raw-value\":%s,"
     "\"raw-instant-value\":%s,"
-    "\"raw-units\":\"percent\","  
+    "\"raw-units\":\"percent\","
     "\"sensor-part-number\":\"SHT25\""
     "%s"
-    "}", 
-    mqtt_client_id, 
-    converted_value_string, 
-    raw_value_string, 
-    raw_instant_value_string, 
-    gps_mqtt_string);  
+    "}",
+    mqtt_client_id,
+    converted_value_string,
+    raw_value_string,
+    raw_instant_value_string,
+    gps_mqtt_string);
 
   replace_character(scratch, '\'', '\"');
 
   strcat(MQTT_TOPIC_STRING, MQTT_TOPIC_PREFIX);
-  strcat(MQTT_TOPIC_STRING, "humidity");    
+  strcat(MQTT_TOPIC_STRING, "humidity");
   if(mqtt_suffix_enabled){
-    strcat(MQTT_TOPIC_STRING, "/");      
-    strcat(MQTT_TOPIC_STRING, mqtt_client_id);      
-  }  
+    strcat(MQTT_TOPIC_STRING, "/");
+    strcat(MQTT_TOPIC_STRING, mqtt_client_id);
+  }
   return mqttPublish(MQTT_TOPIC_STRING, scratch);
 }
 
 void collectTemperature(void){
   if(init_sht25_ok){
     if(sht25.getTemperature(&instant_temperature_degc)){
-      addSample(TEMPERATURE_SAMPLE_BUFFER, instant_temperature_degc);       
+      addSample(TEMPERATURE_SAMPLE_BUFFER, instant_temperature_degc);
       if(sample_buffer_idx == (sample_buffer_depth - 1)){
         temperature_ready = true;
       }
@@ -4959,7 +4959,7 @@ void collectTemperature(void){
 void collectHumidity(void){
   if(init_sht25_ok){
     if(sht25.getRelativeHumidity(&instant_humidity_percent)){
-      addSample(HUMIDITY_SAMPLE_BUFFER, instant_humidity_percent);       
+      addSample(HUMIDITY_SAMPLE_BUFFER, instant_humidity_percent);
       if(sample_buffer_idx == (sample_buffer_depth - 1)){
         humidity_ready = true;
       }
@@ -4973,31 +4973,31 @@ void collectHumidity(void){
 void collectTouch(void){
   static uint8_t sample_write_index = 0;
   touch_sample_buffer[sample_write_index++] = touch.capacitiveSensor(30);
-  
+
   if(sample_write_index == TOUCH_SAMPLE_BUFFER_DEPTH){
-    sample_write_index = 0; 
+    sample_write_index = 0;
   }
 }
 
 boolean processTouchVerbose(boolean verbose_output){
-  const uint32_t touch_event_threshold = 85UL;  
+  const uint32_t touch_event_threshold = 85UL;
   static boolean first_time = true;
   static unsigned long touch_start_millis = 0UL;
-  long backlight_interval = 60000L; 
+  long backlight_interval = 60000L;
   static boolean backlight_is_on = false;
   boolean ret = false;
- 
+
   if(first_time){
     first_time = false;
-    backlight_interval = ((long) eeprom_read_word((uint16_t *) EEPROM_BACKLIGHT_DURATION)) * 1000;    
+    backlight_interval = ((long) eeprom_read_word((uint16_t *) EEPROM_BACKLIGHT_DURATION)) * 1000;
   }
-  
-  float touch_moving_average = calculateAverage(touch_sample_buffer, TOUCH_SAMPLE_BUFFER_DEPTH); 
+
+  float touch_moving_average = calculateAverage(touch_sample_buffer, TOUCH_SAMPLE_BUFFER_DEPTH);
   if(verbose_output){
     Serial.print(F("Info: Average Touch Reading: "));
     Serial.println(touch_moving_average);
   }
-  
+
   if(touch_moving_average > touch_event_threshold){
     backlightOn();
     backlight_is_on = true;
@@ -5006,17 +5006,17 @@ boolean processTouchVerbose(boolean verbose_output){
     }
     touch_start_millis = current_millis;
     ret = true;
-  } 
-  
-  if((current_millis - touch_start_millis) >= backlight_interval) {        
-    if(backlight_is_on){      
+  }
+
+  if((current_millis - touch_start_millis) >= backlight_interval) {
+    if(backlight_is_on){
       if(verbose_output){
-        Serial.println(F("Info: Turning backlight off (timer expired)."));   
+        Serial.println(F("Info: Turning backlight off (timer expired)."));
       }
-      backlightOff();      
-      backlight_is_on = false;      
+      backlightOff();
+      backlight_is_on = false;
     }
-  }  
+  }
 
   return ret;
 }
@@ -5038,19 +5038,19 @@ void advanceSampleBufferIndex(void){
 
 void addSample(uint8_t sample_type, float value){
   if((sample_type < NUM_SAMPLE_BUFFERS) && (sample_buffer_idx < MAX_SAMPLE_BUFFER_DEPTH)){
-    sample_buffer[sample_type][sample_buffer_idx] = value;    
+    sample_buffer[sample_type][sample_buffer_idx] = value;
   }
 }
 
 
-void collectCO2(void){    
+void collectCO2(void){
   co2Serial.begin(9600);
   clearCO2SerialInput();
 
   //Serial.print("CO2:");
-  if(requestCO2Data(&instant_co2_ppm)){      
+  if(requestCO2Data(&instant_co2_ppm)){
     //Serial.print(instant_co2_ppm, 1);
-    addSample(CO2_SAMPLE_BUFFER, instant_co2_ppm);   
+    addSample(CO2_SAMPLE_BUFFER, instant_co2_ppm);
     if(sample_buffer_idx == (sample_buffer_depth - 1)){
       co2_ready = true;
     }
@@ -5061,19 +5061,19 @@ void collectCO2(void){
     watchdogForceReset();
   }
   //Serial.println();
-  
-  co2Serial.end();  
+
+  co2Serial.end();
 }
 
 float pressure_scale_factor(void){
   float ret = 1.0f;
-  
+
   static boolean first_access = true;
   static int16_t user_altitude_meters = 0.0f;
-  
+
   if(first_access){
     first_access = false;
-    user_altitude_meters = (int16_t) eeprom_read_word((uint16_t *) EEPROM_ALTITUDE_METERS);       
+    user_altitude_meters = (int16_t) eeprom_read_word((uint16_t *) EEPROM_ALTITUDE_METERS);
   }
 
   int16_t altitude_meters = user_altitude_meters;
@@ -5086,20 +5086,20 @@ float pressure_scale_factor(void){
     const float kelvin_offset = 273.15f;
     const float lapse_rate_kelvin_per_meter = -0.0065f;
     const float pressure_exponentiation_constant = 5.2558774324f;
-    
+
     float outside_temperature_kelvin = kelvin_offset + (temperature_degc - reported_temperature_offset_degC);
     float outside_temperature_kelvin_at_sea_level = outside_temperature_kelvin - lapse_rate_kelvin_per_meter * altitude_meters; // lapse rate is negative
     float pow_arg = 1.0f + ((lapse_rate_kelvin_per_meter * altitude_meters) / outside_temperature_kelvin_at_sea_level);
     ret = powf(pow_arg, pressure_exponentiation_constant);
   }
-  
+
   return ret;
 }
 
 void co2_convert_to_ppm(float average, float * converted_value, float * temperature_compensated_value){
   static boolean first_access = true;
   static float co2_zero_volts = 0.0f;
-  if(first_access){   
+  if(first_access){
     co2_zero_volts = eeprom_read_float((const float *) EEPROM_CO2_CAL_OFFSET);
     first_access = false;
   }
@@ -5108,8 +5108,8 @@ void co2_convert_to_ppm(float average, float * converted_value, float * temperat
   // TODO: apply compensation formula using temperature dependant parameters here
 
   // there's no interpretation needed for this sensor, we don't actually have any "raw" data
-  *converted_value = average; 
-  
+  *converted_value = average;
+
   *temperature_compensated_value = *converted_value; // no compensation yet
   if(*temperature_compensated_value <= 0.0f){
     *temperature_compensated_value = 0.0f;
@@ -5118,67 +5118,67 @@ void co2_convert_to_ppm(float average, float * converted_value, float * temperat
 
 boolean publishCO2(){
   clearTempBuffers();
-  uint16_t num_samples = co2_ready ? sample_buffer_depth : sample_buffer_idx;  
-  float converted_value = 0.0f, compensated_value = 0.0f;    
+  uint16_t num_samples = co2_ready ? sample_buffer_depth : sample_buffer_idx;
+  float converted_value = 0.0f, compensated_value = 0.0f;
   float co2_moving_average = calculateAverage(&(sample_buffer[CO2_SAMPLE_BUFFER][0]), num_samples);
   co2_convert_to_ppm(co2_moving_average, &converted_value, &compensated_value);
-  co2_ppm = compensated_value;  
+  co2_ppm = compensated_value;
   //safe_dtostrf(co2_moving_average, -8, 5, raw_value_string, 16);
   safe_dtostrf(converted_value, -8, 0, converted_value_string, 16);
-  safe_dtostrf(compensated_value, -8, 0, compensated_value_string, 16); 
+  safe_dtostrf(compensated_value, -8, 0, compensated_value_string, 16);
   safe_dtostrf(instant_co2_ppm, -8, 0, raw_instant_value_string, 16);
-  
+
   //trim_string(raw_value_string);
   trim_string(converted_value_string);
-  trim_string(compensated_value_string);  
+  trim_string(compensated_value_string);
   trim_string(raw_instant_value_string);
-  
+
   //replace_nan_with_null(raw_value_string);
   replace_nan_with_null(converted_value_string);
   replace_nan_with_null(compensated_value_string);
   replace_nan_with_null(raw_instant_value_string);
-  
-  snprintf(scratch, SCRATCH_BUFFER_SIZE-1, 
+
+  snprintf(scratch, SCRATCH_BUFFER_SIZE-1,
     "{"
-    "\"serial-number\":\"%s\","   
-    "\"raw-instant-value\":%s,"    
+    "\"serial-number\":\"%s\","
+    "\"raw-instant-value\":%s,"
     "\"converted-value\":%s,"
-    "\"converted-units\":\"ppm\","    
+    "\"converted-units\":\"ppm\","
     "\"compensated-value\":%s,"
     "\"sensor-part-number\":\"SE-0018\""
     "%s"
     "}",
-    mqtt_client_id,    
+    mqtt_client_id,
     raw_instant_value_string,
-    converted_value_string, 
+    converted_value_string,
     compensated_value_string,
-    gps_mqtt_string);  
+    gps_mqtt_string);
 
   replace_character(scratch, '\'', '\"'); // replace single quotes with double quotes
-  
+
   strcat(MQTT_TOPIC_STRING, MQTT_TOPIC_PREFIX);
-  strcat(MQTT_TOPIC_STRING, "co2");    
+  strcat(MQTT_TOPIC_STRING, "co2");
   if(mqtt_suffix_enabled){
-    strcat(MQTT_TOPIC_STRING, "/");      
-    strcat(MQTT_TOPIC_STRING, mqtt_client_id);      
+    strcat(MQTT_TOPIC_STRING, "/");
+    strcat(MQTT_TOPIC_STRING, mqtt_client_id);
   }
-  return mqttPublish(MQTT_TOPIC_STRING, scratch);        
+  return mqttPublish(MQTT_TOPIC_STRING, scratch);
 }
 
 void petWatchdog(void){
-  tinywdt.pet(); 
+  tinywdt.pet();
 }
 
 void delayForWatchdog(void){
-  delay(120); 
+  delay(120);
 }
 
 void watchdogForceReset(void){
-  tinywdt.force_reset(); 
+  tinywdt.force_reset();
   Serial.println(F("Error: Watchdog Force Restart failed. Manual reset is required."));
   setLCD_P(PSTR("AUTORESET FAILED"
-                " RESET REQUIRED "));                
-  backlightOn();                
+                " RESET REQUIRED "));
+  backlightOn();
   ERROR_MESSAGE_DELAY();
   for(;;){
     delay(1000);
@@ -5186,72 +5186,72 @@ void watchdogForceReset(void){
 }
 
 void watchdogInitialize(void){
-  tinywdt.begin(100, 65000); 
+  tinywdt.begin(100, 65000);
 }
 
 // modal operation loop functions
 void loop_wifi_mqtt_mode(void){
   static uint8_t num_mqtt_connect_retries = 0;
-  static uint8_t num_mqtt_intervals_without_wifi = 0; 
+  static uint8_t num_mqtt_intervals_without_wifi = 0;
   static uint8_t publish_counter = 0;
-  
+
   // mqtt publish timer intervals
   static unsigned long previous_mqtt_publish_millis = 0;
-    
+
   mqttReconnect(); // mqtt_client.loop gets called in here
-  
-  if(current_millis - previous_mqtt_publish_millis >= reporting_interval){   
-    suspendGpsProcessing();    
-    previous_mqtt_publish_millis = current_millis;      
-    
+
+  if(current_millis - previous_mqtt_publish_millis >= reporting_interval){
+    suspendGpsProcessing();
+    previous_mqtt_publish_millis = current_millis;
+
     printCsvDataLine();
-    
+
     if(connectedToNetwork()){
       num_mqtt_intervals_without_wifi = 0;
-      
-      if(mqttReconnect()){         
+
+      if(mqttReconnect()){
         updateLCD("TEMP ", 0, 0, 5, false);
-        updateLCD("RH ", 10, 0, 3, false);         
-        updateLCD("CO2 ", 0, 1, 4, false);        
-                      
-        //connected to MQTT server and connected to Wi-Fi network        
-        num_mqtt_connect_retries = 0;   
-        if((publish_counter % 10) == 0){ // only publish heartbeats every 10 reporting intervals          
+        updateLCD("RH ", 10, 0, 3, false);
+        updateLCD("CO2 ", 0, 1, 4, false);
+
+        //connected to MQTT server and connected to Wi-Fi network
+        num_mqtt_connect_retries = 0;
+        if((publish_counter % 10) == 0){ // only publish heartbeats every 10 reporting intervals
           if(!publishHeartbeat()){
-            Serial.println(F("Error: Failed to publish Heartbeat."));  
+            Serial.println(F("Error: Failed to publish Heartbeat."));
           }
         }
-        
+
         if(init_sht25_ok){
           if(temperature_ready|| (sample_buffer_idx > 0)){
-            if(!publishTemperature()){          
-              Serial.println(F("Error: Failed to publish Temperature."));    
+            if(!publishTemperature()){
+              Serial.println(F("Error: Failed to publish Temperature."));
             }
             else{
               float reported_temperature = temperature_degc - reported_temperature_offset_degC;
               if(temperature_units == 'F'){
                 reported_temperature = toFahrenheit(reported_temperature);
               }
-              updateLCD(reported_temperature, 5, 0, 3, false);             
+              updateLCD(reported_temperature, 5, 0, 3, false);
             }
           }
           else{
             updateLCD("---", 5, 0, 3, false);
-          }        
+          }
         }
         else{
           // sht25 is not ok
           updateLCD("XXX", 5, 0, 3, false);
         }
-        
+
         if(init_sht25_ok){
           if(humidity_ready || (sample_buffer_idx > 0)){
             if(!publishHumidity()){
-              Serial.println(F("Error: Failed to publish Humidity."));  
+              Serial.println(F("Error: Failed to publish Humidity."));
             }
             else{
               float reported_relative_humidity_percent = relative_humidity_percent - reported_humidity_offset_percent;
-              updateLCD(reported_relative_humidity_percent, 13, 0, 3, false);  
+              updateLCD(reported_relative_humidity_percent, 13, 0, 3, false);
             }
           }
           else{
@@ -5261,19 +5261,19 @@ void loop_wifi_mqtt_mode(void){
         else{
           updateLCD("XXX", 13, 0, 3, false);
         }
-        
-        
+
+
         if(co2_ready || (sample_buffer_idx > 0)){
           if(!publishCO2()){
             Serial.println(F("Error: Failed to publish CO2."));
           }
           else{
-            updateLCD(co2_ppm, 5, 1, 5, false);  
+            updateLCD(co2_ppm, 5, 1, 5, false);
           }
         }
         else{
-          updateLCD("---", 5, 1, 5, false); 
-        }  
+          updateLCD("---", 5, 1, 5, false);
+        }
 
         repaintLCD();
       }
@@ -5284,18 +5284,18 @@ void loop_wifi_mqtt_mode(void){
         Serial.print(num_mqtt_connect_retries);
         Serial.print(F(" consecutive time"));
         if(num_mqtt_connect_retries > 1){
-          Serial.print(F("s"));           
+          Serial.print(F("s"));
         }
         Serial.println();
-        
+
         if(num_mqtt_connect_retries >= 5){
           Serial.println(F("Error: MQTT Connect Failed 5 consecutive times. Forcing reboot."));
           Serial.flush();
           setLCD_P(PSTR("  MQTT SERVER   "
                         "    FAILURE     "));
           lcdFrownie(15, 1);
-          ERROR_MESSAGE_DELAY();            
-          watchdogForceReset();  
+          ERROR_MESSAGE_DELAY();
+          watchdogForceReset();
         }
       }
     }
@@ -5308,36 +5308,36 @@ void loop_wifi_mqtt_mode(void){
       if(num_mqtt_intervals_without_wifi > 1){
         Serial.print(F("s"));
       }
-      Serial.println();      
+      Serial.println();
       if(num_mqtt_intervals_without_wifi >= 5){
         Serial.println(F("Error: Wi-Fi Re-connect Failed 5 consecutive times. Forcing reboot."));
         Serial.flush();
         setLCD_P(PSTR(" WI-FI NETWORK  "
                       "    FAILURE     "));
         lcdFrownie(15, 1);
-        ERROR_MESSAGE_DELAY();         
-        watchdogForceReset();  
+        ERROR_MESSAGE_DELAY();
+        watchdogForceReset();
       }
-      
+
       restartWifi();
     }
 
     publish_counter++;
-  }    
+  }
 }
 
 void loop_offline_mode(void){
-  
+
   // write record timer intervals
   static unsigned long previous_write_record_millis = 0;
   static boolean first = true;
 
-  if(first || (current_millis - previous_write_record_millis >= reporting_interval)){ 
+  if(first || (current_millis - previous_write_record_millis >= reporting_interval)){
     first = false;
-    suspendGpsProcessing();   
+    suspendGpsProcessing();
     previous_write_record_millis = current_millis;
     printCsvDataLine();
-  }  
+  }
 }
 
 /****** SIGNAL PROCESSING MATH SUPPORT FUNCTIONS ******/
@@ -5346,33 +5346,33 @@ float calculateAverage(float * buf, uint16_t num_samples){
   float average = 0.0f;
   for(uint16_t ii = 0; ii < num_samples; ii++){
     average += buf[ii];
-  } 
-  
+  }
+
   return average / num_samples;
 }
 
 void printCsvDataLine(){
   static boolean first = true;
-  char * dataString = &(scratch[0]);  
+  char * dataString = &(scratch[0]);
   clearTempBuffers();
   static uint32_t call_counter = 0;
-  
+
   uint16_t len = 0;
   uint16_t dataStringRemaining = SCRATCH_BUFFER_SIZE-1;
-  
-  if(first){   
-    first = false;      
-    Serial.print(F("csv: "));    
+
+  if(first){
+    first = false;
+    Serial.print(F("csv: "));
     Serial.print(header_row);
     Serial.println();
-  }  
-  
+  }
+
   Serial.print(F("csv: "));
   printCurrentTimestamp(dataString, &dataStringRemaining);
   Serial.print(F(","));
   appendToString("," , dataString, &dataStringRemaining);
-  
-  uint16_t num_samples = temperature_ready ? sample_buffer_depth : sample_buffer_idx;  
+
+  uint16_t num_samples = temperature_ready ? sample_buffer_depth : sample_buffer_idx;
 
   if(init_sht25_ok && (temperature_ready || (sample_buffer_idx > 0))){
     temperature_degc = calculateAverage(&(sample_buffer[TEMPERATURE_SAMPLE_BUFFER][0]), num_samples);
@@ -5387,35 +5387,35 @@ void printCsvDataLine(){
     Serial.print(F("---"));
     appendToString("---", dataString, &dataStringRemaining);
   }
-  
+
   Serial.print(F(","));
   appendToString("," , dataString, &dataStringRemaining);
-  
+
   num_samples = humidity_ready ? sample_buffer_depth : sample_buffer_idx;
   if(init_sht25_ok && (humidity_ready || (sample_buffer_idx > 0))){
     relative_humidity_percent = calculateAverage(&(sample_buffer[HUMIDITY_SAMPLE_BUFFER][0]), num_samples);
-    float reported_relative_humidity = relative_humidity_percent - reported_humidity_offset_percent;        
+    float reported_relative_humidity = relative_humidity_percent - reported_humidity_offset_percent;
     Serial.print(reported_relative_humidity, 2);
     appendToString(reported_relative_humidity, 2, dataString, &dataStringRemaining);
   }
   else{
     Serial.print(F("---"));
     appendToString("---", dataString, &dataStringRemaining);
-  }    
-  
+  }
+
   Serial.print(F(","));
   appendToString("," , dataString, &dataStringRemaining);
-  
+
   float co2_moving_average = 0.0f;
   num_samples = co2_ready ? sample_buffer_depth : sample_buffer_idx;
   if(co2_ready || (sample_buffer_idx > 0)){
-    float converted_value = 0.0f, compensated_value = 0.0f;    
+    float converted_value = 0.0f, compensated_value = 0.0f;
     co2_moving_average = calculateAverage(&(sample_buffer[CO2_SAMPLE_BUFFER][0]), num_samples);
     co2_convert_to_ppm(co2_moving_average, &converted_value, &compensated_value);
-    co2_ppm = compensated_value;        
-    
+    co2_ppm = compensated_value;
+
     Serial.print(co2_moving_average, 0);
-    appendToString(co2_moving_average, 0, dataString, &dataStringRemaining);    
+    appendToString(co2_moving_average, 0, dataString, &dataStringRemaining);
   }
   else{
     Serial.print(F("---"));
@@ -5424,21 +5424,21 @@ void printCsvDataLine(){
 
   Serial.print(gps_csv_string);
   appendToString(gps_csv_string, dataString, &dataStringRemaining);
-  
+
   Serial.println();
-  appendToString("\n", dataString, &dataStringRemaining);  
-        
-  if((call_counter % 10) == 0){ // once every 10 reports    
+  appendToString("\n", dataString, &dataStringRemaining);
+
+  if((call_counter % 10) == 0){ // once every 10 reports
     clearLCD(false);
     if((mode == SUBMODE_OFFLINE) && init_sdcard_ok){
       char filename[16] = {0};
-      getNowFilename(filename, 15);     
+      getNowFilename(filename, 15);
       File dataFile = SD.open(filename, FILE_WRITE);
       if (dataFile) {
         dataFile.print(dataString);
         dataFile.close();
         setLCD_P(PSTR("  LOGGING DATA  "
-                      "   TO SD CARD   "));   
+                      "   TO SD CARD   "));
       }
       else {
         Serial.print("Error: Failed to open SD card file named \"");
@@ -5446,7 +5446,7 @@ void printCsvDataLine(){
         Serial.println(F("\""));
         setLCD_P(PSTR("  SD CARD FILE  "
                       "  OPEN FAILED   "));
-        lcdFrownie(15, 1);      
+        lcdFrownie(15, 1);
       }
     }
     else if((mode == SUBMODE_OFFLINE) && !init_sdcard_ok){
@@ -5457,44 +5457,44 @@ void printCsvDataLine(){
   else { // otherwise display the data
     clearLCD(false);
     updateLCD("TEMP ", 0, 0, 5, false);
-    updateLCD("RH ", 10, 0, 3, false);         
+    updateLCD("RH ", 10, 0, 3, false);
     updateLCD("CO2 ", 0, 1, 4, false);
-                      
+
     if(init_sht25_ok){
       float reported_temperature = temperature_degc - reported_temperature_offset_degC;
       if(temperature_units == 'F'){
         reported_temperature = toFahrenheit(reported_temperature);
       }
-      updateLCD(reported_temperature, 5, 0, 3, false);             
+      updateLCD(reported_temperature, 5, 0, 3, false);
     }
     else{
       // sht25 is not ok
       updateLCD("XXX", 5, 0, 3, false);
     }
-    
+
     if(init_sht25_ok){
       float reported_relative_humidity_percent = relative_humidity_percent - reported_humidity_offset_percent;
-      updateLCD(reported_relative_humidity_percent, 13, 0, 3, false);        
+      updateLCD(reported_relative_humidity_percent, 13, 0, 3, false);
     }
     else{
       updateLCD("XXX", 13, 0, 3, false);
     }
-    
-    updateLCD(co2_ppm, 5, 1, 5, false);  
 
-    repaintLCD();    
+    updateLCD(co2_ppm, 5, 1, 5, false);
+
+    repaintLCD();
   }
-  
+
   call_counter++;
 }
 
 boolean mode_requires_wifi(uint8_t opmode){
   boolean requires_wifi = false;
-  
+
   if(opmode == SUBMODE_NORMAL){
     requires_wifi = true;
-  } 
-  
+  }
+
   return requires_wifi;
 }
 
@@ -5503,7 +5503,7 @@ boolean mode_requires_wifi(uint8_t opmode){
 // the following defines are what goes in the SPI flash where to signal to the bootloader
 #define LAST_4K_PAGE_ADDRESS      0x7F000     // the start address of the last 4k page
 #define MAGIC_NUMBER              0x00ddba11  // this word at the end of SPI flash
-                                              // is a signal to the bootloader to 
+                                              // is a signal to the bootloader to
                                               // think about loading it
 #define MAGIC_NUMBER_ADDRESS      0x7FFFC     // the last 4 bytes are the magic number
 #define CRC16_CHECKSUM_ADDRESS    0x7FFFA     // the two bytes before the magic number
@@ -5511,21 +5511,21 @@ boolean mode_requires_wifi(uint8_t opmode){
 #define FILESIZE_ADDRESS          0x7FFF6     // the four bytes before the checksum
                                               // are the stored file size
 
-#define IDLE_TIMEOUT_MS  10000     // Amount of time to wait (in milliseconds) with no data 
+#define IDLE_TIMEOUT_MS  10000     // Amount of time to wait (in milliseconds) with no data
                                    // received before closing the connection.  If you know the server
                                    // you're accessing is quick to respond, you can reduce this value.
 
 void invalidateSignature(void){
   flash_file_size = 0;
-  flash_signature = 0;  
-  while(flash.busy()){;}   
+  flash_signature = 0;
+  while(flash.busy()){;}
   flash.blockErase4K(LAST_4K_PAGE_ADDRESS);
-  while(flash.busy()){;}   
+  while(flash.busy()){;}
 }
 
 uint16_t download_body_crc16_checksum = 0;
 uint32_t download_body_bytes_received = 0;
-boolean download_past_header = false; 
+boolean download_past_header = false;
 uint32_t download_content_length = 0;
 
 void downloadHandleHeader(char * key, char * value){
@@ -5534,23 +5534,23 @@ void downloadHandleHeader(char * key, char * value){
 //  Serial.print("\" => \"");
 //  Serial.print(value);
 //  Serial.println("\"");
-  
+
   if(strcmp(key, "Content-Length") == 0){
-    download_content_length = strtoul(value, NULL, 10);   
+    download_content_length = strtoul(value, NULL, 10);
   }
 }
 
 uint32_t downloadProcessHeader(uint8_t * data, uint32_t data_length){
-  uint32_t start_index = 0;         
-  static uint8_t header_guard_index = 0; 
+  uint32_t start_index = 0;
+  static uint8_t header_guard_index = 0;
   static boolean past_first_line = false;
   static char key[64] = {0};
   static char value[64] = {0};
   static uint8_t key_or_value = 0;
   static uint8_t keyval_index = 0;
-  
+
   if(!download_past_header){
-    for(uint32_t ii = 0; ii < data_length; ii++){                 
+    for(uint32_t ii = 0; ii < data_length; ii++){
       switch(header_guard_index){
       case 0:
         if(data[ii] == '\r') header_guard_index++;
@@ -5573,84 +5573,84 @@ uint32_t downloadProcessHeader(uint8_t * data, uint32_t data_length){
       case 1:
         if(data[ii] == '\n'){
           header_guard_index++;
-          
+
           if(past_first_line){
             downloadHandleHeader((char *) key, (char *) value);
           }
-          
+
           past_first_line = true;
           key_or_value = 0;
           keyval_index = 0;
           memset(key, 0, 64);
-          memset(value, 0, 64);          
+          memset(value, 0, 64);
         }
-        else header_guard_index = 0;        
+        else header_guard_index = 0;
         break;
       case 2:
         if(data[ii] == '\r') header_guard_index++;
         else{
           key[keyval_index++] = data[ii];
-          header_guard_index = 0;         
+          header_guard_index = 0;
         }
         break;
       case 3:
         if(data[ii] == '\n') header_guard_index++;
-        else header_guard_index = 0;         
+        else header_guard_index = 0;
         break;
-      case 4:        
+      case 4:
         download_past_header = true;
         start_index = ii;
         header_guard_index = 0;
         break;
-      }      
+      }
     }
-  }  
+  }
 
   return start_index;
 }
 
-void downloadFile(char * hostname, uint16_t port, char * filename, void (*responseBodyProcessor)(uint8_t *, uint32_t)){      
+void downloadFile(char * hostname, uint16_t port, char * filename, void (*responseBodyProcessor)(uint8_t *, uint32_t)){
   unsigned long total_bytes_read = 0;
   uint8_t mybuffer[64] = {0};
-  
+
   // re-initialize the globals
   download_body_crc16_checksum = 0;
-  download_body_bytes_received = 0;   
-  download_past_header = false;  
+  download_body_bytes_received = 0;
+  download_past_header = false;
   download_content_length = 0;
-  
+
   /* Try connecting to the website.
      Note: HTTP/1.1 protocol is used to keep the server from closing the connection before all data is read.
-  */ 
+  */
   esp.connect(hostname, port);
-  if (esp.connected()) {   
+  if (esp.connected()) {
     memset(scratch, 0, SCRATCH_BUFFER_SIZE);
-    snprintf(scratch, SCRATCH_BUFFER_SIZE-1, "GET /%s HTTP/1.1\r\nHost: %s\r\n\r\n\r\n", filename, hostname);        
+    snprintf(scratch, SCRATCH_BUFFER_SIZE-1, "GET /%s HTTP/1.1\r\nHost: %s\r\n\r\n\r\n", filename, hostname);
     esp.print(scratch);
-    //Serial.print(scratch);    
+    //Serial.print(scratch);
   } else {
-    Serial.println(F("Error: Server Connection failed"));    
+    Serial.println(F("Error: Server Connection failed"));
     return;
   }
 
   Serial.println(F("Info: -------------------------------------"));
-  
-  /* Read data until either the connection is closed, or the idle timeout is reached. */ 
-  unsigned long lastRead = millis(); 
-  unsigned long num_bytes_read = 0;  
+
+  /* Read data until either the connection is closed, or the idle timeout is reached. */
+  unsigned long lastRead = millis();
+  unsigned long num_bytes_read = 0;
   unsigned long start_time = millis();
   uint32_t loop_counter = 0;
-  
-  while (esp.connected(false) && (millis() - lastRead < IDLE_TIMEOUT_MS)) {        
+
+  while (esp.connected(false) && (millis() - lastRead < IDLE_TIMEOUT_MS)) {
     while (esp.available()) {
       //char c = esp.read();
-      num_bytes_read = esp.read(mybuffer, 64);     
+      num_bytes_read = esp.read(mybuffer, 64);
       total_bytes_read += num_bytes_read;
 
       if(loop_counter == 4096){
         Serial.print("Info: ");
       }
-      
+
       loop_counter++;
       if((loop_counter % 4096) == 0){
         Serial.print(".");
@@ -5660,40 +5660,40 @@ void downloadFile(char * hostname, uint16_t port, char * filename, void (*respon
 
       if(responseBodyProcessor != 0){
         responseBodyProcessor(mybuffer, num_bytes_read); // signal end of stream
-      }        
-        
+      }
+
       lastRead = millis();
     }
   }
-  
+
   esp.stop();
-  
-  Serial.println();  
+
+  Serial.println();
   Serial.println("Info: Download Complete");
   Serial.print("Info: Total Bytes: ");
   Serial.println(total_bytes_read);
   Serial.print("Info: File Size: ");
   Serial.println(download_body_bytes_received);
   Serial.print("Info: Checksum: ");
-  Serial.println(download_body_crc16_checksum);  
+  Serial.println(download_body_crc16_checksum);
   Serial.print("Info: Duration: ");
-  Serial.println(millis() - start_time);   
-    
+  Serial.println(millis() - start_time);
+
 }
 
 void processChkResponseData(uint8_t * data, uint32_t data_length){
   uint32_t start_index = downloadProcessHeader(data, data_length);
   char * endPtr;
   static char buff[64] = {0};
-  static uint8_t buff_idx = 0;  
-    
-  if(download_past_header){       
-    for(uint32_t ii = start_index; ii < data_length; ii++){     
+  static uint8_t buff_idx = 0;
+
+  if(download_past_header){
+    for(uint32_t ii = start_index; ii < data_length; ii++){
       download_body_bytes_received++;
       download_body_crc16_checksum = _crc16_update(download_body_crc16_checksum, data[ii]);
       if(buff_idx < 63){
-        buff[buff_idx++] = data[ii];         
-      }      
+        buff[buff_idx++] = data[ii];
+      }
     }
 
     if(download_body_bytes_received == download_content_length){
@@ -5706,11 +5706,11 @@ void processChkResponseData(uint8_t * data, uint32_t data_length){
       Serial.print(  "Info:    File Size: ");
       Serial.println(integrity_num_bytes_total);
       Serial.print(  "Info:    CRC16 Checksum: ");
-      Serial.println(integrity_crc16_checksum);    
+      Serial.println(integrity_crc16_checksum);
     }
-    
+
   }
-    
+
 }
 
 void processHexResponseData(uint8_t * data, uint32_t data_length){
@@ -5719,32 +5719,32 @@ void processHexResponseData(uint8_t * data, uint32_t data_length){
   static uint16_t page_idx = 0;
   static uint32_t page_address = 0;
   static uint32_t local_download_body_bytes_received = 0;
-  
-  if(download_past_header){   
-    for(uint32_t ii = start_index; ii < data_length; ii++){     
+
+  if(download_past_header){
+    for(uint32_t ii = start_index; ii < data_length; ii++){
       download_body_bytes_received++;
       download_body_crc16_checksum = _crc16_update(download_body_crc16_checksum, data[ii]);
 
       if(page_idx < 256){
-        page[page_idx++] = data[ii];  
+        page[page_idx++] = data[ii];
         if(page_idx >= 256){
            page_idx = 0;
         }
-      }     
+      }
 
-      if((download_body_bytes_received == download_content_length) || (page_idx == 0)){       
+      if((download_body_bytes_received == download_content_length) || (page_idx == 0)){
         uint16_t top_bound = 256;
         if(page_idx != 0){
           top_bound = page_idx;
         }
         flash.writeBytes(page_address, page, top_bound);
-                
+
         // clear the page
         memset(page, 0, 256);
-        
+
         // advance the page address
-        page_address += 256;        
-      }       
+        page_address += 256;
+      }
     }
 
     if(download_body_bytes_received == download_content_length){
@@ -5766,169 +5766,169 @@ void processHexResponseData(uint8_t * data, uint32_t data_length){
     }
 
   }
-    
+
 }
 
-void checkForFirmwareUpdates(){ 
+void checkForFirmwareUpdates(){
   static char filename[64] = {0};
   memset(filename, 0, 64);
-  
+
   if(updateServerResolve()){
-    // try and download the integrity check file up to three times    
+    // try and download the integrity check file up to three times
     setLCD_P(PSTR("  CHECKING FOR  "
                   "    UPDATES     "));
     eeprom_read_block(filename, (const void *) EEPROM_UPDATE_FILENAME, 31);
-    strncat_P(filename, PSTR(".chk"), 4);    
-      
-    downloadFile(update_server_name, 80, filename, processChkResponseData);   
+    strncat_P(filename, PSTR(".chk"), 4);
+
+    downloadFile(update_server_name, 80, filename, processChkResponseData);
     if(downloaded_integrity_file){
       lcdSmiley(15, 1);
       SUCCESS_MESSAGE_DELAY();
-      delayForWatchdog();        
-      petWatchdog();        
+      delayForWatchdog();
+      petWatchdog();
     }
 
     if(downloaded_integrity_file){
-      // compare the just-retrieved signature file contents 
+      // compare the just-retrieved signature file contents
       // to the signature already stored in flash
-      if((flash_file_size != integrity_num_bytes_total) || 
-        (flash_signature != integrity_crc16_checksum)){                 
-        
+      if((flash_file_size != integrity_num_bytes_total) ||
+        (flash_signature != integrity_crc16_checksum)){
+
         setLCD_P(PSTR("UPDATE AVAILABLE"
-                      "  DOWNLOADING   "));       
-        SUCCESS_MESSAGE_DELAY(); 
-        delayForWatchdog();        
+                      "  DOWNLOADING   "));
+        SUCCESS_MESSAGE_DELAY();
+        delayForWatchdog();
         petWatchdog();
-       
-        
+
+
         memset(filename, 0, 64); // switch to the hex extension
         eeprom_read_block(filename, (const void *) EEPROM_UPDATE_FILENAME, 31);
-        strncat_P(filename, PSTR(".hex"), 4); 
-        
+        strncat_P(filename, PSTR(".hex"), 4);
+
         setLCD_P(PSTR("     PLEASE     "
-                      "      WAIT      "));  
-                      
+                      "      WAIT      "));
+
         Serial.print(F("Info: Downloading \""));
         Serial.print(filename);
         Serial.print(F("\""));
         Serial.println();
-        
-        //before starting the download of the hex file, first erase the flash memory up to the second to last page        
+
+        //before starting the download of the hex file, first erase the flash memory up to the second to last page
         for(uint32_t page = 0; page < SECOND_TO_LAST_4K_PAGE_ADDRESS; page+=4096){
-          while(flash.busy()){;}    
-          flash.blockErase4K(page); 
-          while(flash.busy()){;}           
+          while(flash.busy()){;}
+          flash.blockErase4K(page);
+          while(flash.busy()){;}
         }
-        
-        downloadFile(update_server_name, 80, filename, processHexResponseData);    
-        while(flash.busy()){;}           
-        if(integrity_check_succeeded){ 
+
+        downloadFile(update_server_name, 80, filename, processHexResponseData);
+        while(flash.busy()){;}
+        if(integrity_check_succeeded){
           // also write these parameters to their rightful place in the SPI flash
           // for consumption by the bootloader
-          invalidateSignature();                                 
-          
+          invalidateSignature();
+
           flash.writeByte(CRC16_CHECKSUM_ADDRESS + 0, (integrity_crc16_checksum >> 8) & 0xff);
           flash.writeByte(CRC16_CHECKSUM_ADDRESS + 1, (integrity_crc16_checksum >> 0) & 0xff);
-          
+
           flash.writeByte(FILESIZE_ADDRESS + 0, (integrity_num_bytes_total >> 24) & 0xff);
-          flash.writeByte(FILESIZE_ADDRESS + 1, (integrity_num_bytes_total >> 16) & 0xff);    
+          flash.writeByte(FILESIZE_ADDRESS + 1, (integrity_num_bytes_total >> 16) & 0xff);
           flash.writeByte(FILESIZE_ADDRESS + 2, (integrity_num_bytes_total >> 8)  & 0xff);
-          flash.writeByte(FILESIZE_ADDRESS + 3, (integrity_num_bytes_total >> 0)  & 0xff);                
-          
-          flash.writeByte(MAGIC_NUMBER_ADDRESS + 0, MAGIC_NUMBER >> 24); 
-          flash.writeByte(MAGIC_NUMBER_ADDRESS + 1, MAGIC_NUMBER >> 16); 
-          flash.writeByte(MAGIC_NUMBER_ADDRESS + 2, MAGIC_NUMBER >> 8); 
-          flash.writeByte(MAGIC_NUMBER_ADDRESS + 3, MAGIC_NUMBER >> 0); 
-          Serial.println(F("Info: Wrote Magic Number"));          
-          
+          flash.writeByte(FILESIZE_ADDRESS + 3, (integrity_num_bytes_total >> 0)  & 0xff);
+
+          flash.writeByte(MAGIC_NUMBER_ADDRESS + 0, MAGIC_NUMBER >> 24);
+          flash.writeByte(MAGIC_NUMBER_ADDRESS + 1, MAGIC_NUMBER >> 16);
+          flash.writeByte(MAGIC_NUMBER_ADDRESS + 2, MAGIC_NUMBER >> 8);
+          flash.writeByte(MAGIC_NUMBER_ADDRESS + 3, MAGIC_NUMBER >> 0);
+          Serial.println(F("Info: Wrote Magic Number"));
+
           Serial.println(F("Info: Firmware Update Complete. Reseting to apply changes."));
           setLCD_P(PSTR("APPLYING UPDATES"
-                        "WAIT ONE MINUTE "));          
+                        "WAIT ONE MINUTE "));
           lcdSmiley(15, 1);
           SUCCESS_MESSAGE_DELAY();
-          watchdogForceReset();        
+          watchdogForceReset();
         }
         else{
           Serial.println(F("Error: Firmware Update Failed. Try again later by resetting."));
           setLCD_P(PSTR(" UPDATE FAILED  "
                         "  RETRY LATER   "));
           lcdFrownie(15, 1);
-          ERROR_MESSAGE_DELAY();         
+          ERROR_MESSAGE_DELAY();
         }
       }
       else{
         Serial.println("Info: Signature matches, skipping HEX download.");
         setLCD_P(PSTR("SOFTWARE ALREADY"
-                      "   UP TO DATE   "));       
-        SUCCESS_MESSAGE_DELAY();   
-        delayForWatchdog();        
-        petWatchdog();        
+                      "   UP TO DATE   "));
+        SUCCESS_MESSAGE_DELAY();
+        delayForWatchdog();
+        petWatchdog();
       }
     }
     else{
       Serial.println("Error: Failed to download integrity check file, skipping Hex file download");
-    }    
-  }  
+    }
+  }
 }
 
 boolean updateServerResolve(void){
   static boolean resolved = false;
-  
-  if(connectedToNetwork()){ 
+
+  if(connectedToNetwork()){
     if(!resolved){
-      eeprom_read_block(update_server_name, (const void *) EEPROM_UPDATE_SERVER_NAME, 31);      
+      eeprom_read_block(update_server_name, (const void *) EEPROM_UPDATE_SERVER_NAME, 31);
 
       if(strlen(update_server_name) == 0){
         return false; // this is as indication that OTA updates are disabled
       }
-      
+
       setLCD_P(PSTR("   RESOLVING"));
       updateLCD("UPDATE SERVER", 1);
       SUCCESS_MESSAGE_DELAY();
-      
+
       if  (!esp.getHostByName(update_server_name, &update_server_ip32) || (update_server_ip32 == 0)){
         Serial.print(F("Error: Couldn't resolve '"));
         Serial.print(update_server_name);
         Serial.println(F("'"));
-        
+
         updateLCD("FAILED", 1);
         lcdFrownie(15, 1);
         ERROR_MESSAGE_DELAY();
         return false;
       }
       else{
-        resolved = true;    
+        resolved = true;
         Serial.print(F("Info: Resolved \""));
         Serial.print(update_server_name);
         Serial.print(F("\" to IP address "));
         char ip_str[16] = {0};
         esp.IpUint32ToString(update_server_ip32, &(ip_str[0]));
         Serial.print((char *) ip_str);
-        
-        updateLCD(update_server_ip32, 1);      
+
+        updateLCD(update_server_ip32, 1);
         lcdSmiley(15, 1);
-        SUCCESS_MESSAGE_DELAY();          
-        Serial.println();    
+        SUCCESS_MESSAGE_DELAY();
+        Serial.println();
       }
     }
-     
-    // connected to network and resolution succeeded 
+
+    // connected to network and resolution succeeded
     return true;
   }
-  
+
   // not connected to network
   return false;
 }
 
-void getCurrentFirmwareSignature(void){  
-  // retrieve the current signature parameters  
+void getCurrentFirmwareSignature(void){
+  // retrieve the current signature parameters
   flash_file_size = flash.readByte(FILESIZE_ADDRESS);
   flash_file_size <<= 8;
   flash_file_size |= flash.readByte(FILESIZE_ADDRESS+1);
   flash_file_size <<= 8;
-  flash_file_size |= flash.readByte(FILESIZE_ADDRESS+2);  
+  flash_file_size |= flash.readByte(FILESIZE_ADDRESS+2);
   flash_file_size <<= 8;
-  flash_file_size |= flash.readByte(FILESIZE_ADDRESS+3);  
+  flash_file_size |= flash.readByte(FILESIZE_ADDRESS+3);
 
   flash_signature = flash.readByte(CRC16_CHECKSUM_ADDRESS);
   flash_signature <<= 8;
@@ -5938,21 +5938,21 @@ void getCurrentFirmwareSignature(void){
   Serial.print(flash_file_size);
   Serial.print(F(" "));
   Serial.print(flash_signature);
-  Serial.println();   
+  Serial.println();
 }
 
 /****** CONFIGURATION MIRRORING SUPPORT FUNCTIONS ******/
 void commitConfigToMirroredConfig(void){
-  if(!mirrored_config_matches_eeprom_config()){      
-    mirrored_config_copy_from_eeprom(); // create a valid mirrored config from the current settings             
+  if(!mirrored_config_matches_eeprom_config()){
+    mirrored_config_copy_from_eeprom(); // create a valid mirrored config from the current settings
     if(!mirrored_config_integrity_check()){
-      Serial.println(F("Error: Mirrored configuration commit failed to validate.")); 
+      Serial.println(F("Error: Mirrored configuration commit failed to validate."));
       //TODO: should something be written to the LCD here?
     }
   }
   else{
-    Serial.println(F("Info: Mirrored configuration already matches current configuration.")); 
-  } 
+    Serial.println(F("Info: Mirrored configuration already matches current configuration."));
+  }
 }
 
 boolean mirrored_config_matches_eeprom_config(void){
@@ -5967,36 +5967,36 @@ boolean mirrored_config_matches_eeprom_config(void){
       break;
     }
   }
-  
+
   return ret;
-} 
+}
 
 boolean configMemoryUnlocked(uint16_t call_id){
   if(!allowed_to_write_config_eeprom){
     Serial.print(F("Error: Config Memory is not unlocked, called from line number "));
     Serial.println(call_id);
-    return false; 
+    return false;
   }
-  
+
   return allowed_to_write_config_eeprom;
 }
 
 boolean mirrored_config_integrity_check(){
   boolean ret = false;
   uint16_t computed_crc = computeFlashChecksum();
-  
+
   // interpret the CRC, little endian
   uint16_t stored_crc = getStoredFlashChecksum();
-  
+
   if(stored_crc == computed_crc){
-    ret = true; 
+    ret = true;
   }
-  
-  return ret;  
+
+  return ret;
 }
 
 
-void mirrored_config_restore(void){  
+void mirrored_config_restore(void){
   if(!allowed_to_write_config_eeprom){
     return;
   }
@@ -6010,41 +6010,41 @@ void mirrored_config_restore(void){
 
 boolean mirrored_config_restore_and_validate(void){
   boolean integrity_check_passed = false;
-  
+
   if(mirrored_config_integrity_check()){
     mirrored_config_restore();
     integrity_check_passed = checkConfigIntegrity();
     if(integrity_check_passed){
-      Serial.println(F("Info: Successfully restored to last valid configuration.")); 
+      Serial.println(F("Info: Successfully restored to last valid configuration."));
     }
     else{
       Serial.println(F("Info: Restored last valid configuration, but it's still not valid. Possibly catastrophic."));
-    }  
+    }
   }
   else{
-    Serial.println(F("Error: Mirrored configuration is not valid, cannot restore to last valid configuration.")); 
+    Serial.println(F("Error: Mirrored configuration is not valid, cannot restore to last valid configuration."));
   }
-  
+
   return integrity_check_passed;
 }
 
 void mirrored_config_copy_from_eeprom(void){
-  
+
   mirrored_config_erase();
   Serial.print(F("Info: Writing mirrored config..."));
 
   // copy each byte from the EEPROM into the Flash
   for (uint16_t ii = 0; ii < EEPROM_CONFIG_MEMORY_SIZE; ii++) {
     uint8_t value = eeprom_read_byte((uint8_t *) (EEPROM_CRC_CHECKSUM + ii));
-    flash.writeByte(((uint32_t) SECOND_TO_LAST_4K_PAGE_ADDRESS) + ((uint32_t) ii), value);    
+    flash.writeByte(((uint32_t) SECOND_TO_LAST_4K_PAGE_ADDRESS) + ((uint32_t) ii), value);
   }
   Serial.println(F("OK."));
 }
 
 void mirrored_config_erase(void){
-  Serial.print(F("Info: Erasing mirrored config..."));  
+  Serial.print(F("Info: Erasing mirrored config..."));
   flash.blockErase4K(SECOND_TO_LAST_4K_PAGE_ADDRESS);
-  Serial.println(F("OK."));  
+  Serial.println(F("OK."));
 }
 
 /****** TIMESTAMPING SUPPORT FUNCTIONS ******/
@@ -6056,8 +6056,8 @@ time_t AQE_now(void){
 
 void currentTimestamp(char * dst, uint16_t max_len){
   time_t n = now();
-  
-  snprintf(dst, max_len, "%02d/%02d/%04d %02d:%02d:%02d", 
+
+  snprintf(dst, max_len, "%02d/%02d/%04d %02d:%02d:%02d",
     month(n),
     day(n),
     year(n),
@@ -6070,8 +6070,8 @@ void printCurrentTimestamp(char * append_to, uint16_t * append_to_capacity_and_u
   char datetime[32] = {0};
   currentTimestamp(datetime, 31);
   Serial.print(datetime);
-  
-  appendToString(datetime, append_to, append_to_capacity_and_update);  
+
+  appendToString(datetime, append_to, append_to_capacity_and_update);
 }
 
 void appendToString(char * str, char * append_to, uint16_t * append_to_capacity_and_update){
@@ -6081,7 +6081,7 @@ void appendToString(char * str, char * append_to, uint16_t * append_to_capacity_
       strcat(append_to, str);
       *append_to_capacity_and_update -= len;
     }
-  }  
+  }
 }
 
 void appendToString(float val, uint8_t digits_after_decimal_point, char * append_to, uint16_t * append_to_capacity_and_update){
@@ -6092,7 +6092,7 @@ void appendToString(float val, uint8_t digits_after_decimal_point, char * append
 
 void getNowFilename(char * dst, uint16_t max_len){
   time_t n = now();
-  snprintf(dst, max_len, "%02d%02d%02d%02d.csv", 
+  snprintf(dst, max_len, "%02d%02d%02d%02d.csv",
     year(n) % 100,
     month(n),
     day(n),
@@ -6106,33 +6106,33 @@ void rtcClearOscillatorStopFlag(void){
 
     // control registers
     Wire.requestFrom(DS3231_ADDRESS, 2);
-    uint8_t creg = Wire.read(); 
-    uint8_t sreg = Wire.read();   
-    
+    uint8_t creg = Wire.read();
+    uint8_t sreg = Wire.read();
+
     sreg &= ~_BV(7); // clear bit 7 (msbit)
-    
+
     Wire.beginTransmission(DS3231_ADDRESS);
     Wire.write((uint8_t) DS3231_REG_STATUS_CTL);
     Wire.write((uint8_t) sreg);
-    Wire.endTransmission();    
+    Wire.endTransmission();
 }
 
 /****** GPS SUPPORT FUNCTIONS ******/
 void updateGpsStrings(void){
-  const char * gps_lat_lng_field_mqtt_template = ",\"__location\":{\"lat\":%.6f,\"lon\":%.6f}"; 
-  const char * gps_lat_lng_alt_field_mqtt_template  = ",\"__location\":{\"lat\":%.6f,\"lon\":%.6f,\"alt\":%.2f}"; 
+  const char * gps_lat_lng_field_mqtt_template = ",\"__location\":{\"lat\":%.6f,\"lon\":%.6f}";
+  const char * gps_lat_lng_alt_field_mqtt_template  = ",\"__location\":{\"lat\":%.6f,\"lon\":%.6f,\"alt\":%.2f}";
   const char * gps_lat_lng_field_csv_template = ",%.6f,%.6f,---";
-  const char * gps_lat_lng_alt_field_csv_template  = ",%.6f,%.6f,%.2f";   
+  const char * gps_lat_lng_alt_field_csv_template  = ",%.6f,%.6f,%.2f";
 
   static boolean first = true;
   if(first){
     first = false;
     float tmp = eeprom_read_float((float *) EEPROM_USER_LATITUDE_DEG);
-    // Serial.println(tmp,6);    
+    // Serial.println(tmp,6);
     if(!isnan(tmp) && (tmp >= -90.0f) && (tmp <= 90.0f)){
       user_latitude = tmp;
     }
-    
+
     tmp = eeprom_read_float((float *) EEPROM_USER_LONGITUDE_DEG);
     // Serial.println(tmp,6);
     if(!isnan(tmp) && (tmp >= -180.0f) && (tmp <= 180.0f)){
@@ -6149,20 +6149,20 @@ void updateGpsStrings(void){
     // Serial.println(user_longitude, 6);
     // Serial.println(user_altitude, 2);
   }
-  
+
   memset(gps_mqtt_string, 0, GPS_MQTT_STRING_LENGTH);
   memset(gps_csv_string, 0, GPS_CSV_STRING_LENGTH);
-  
-  if(user_location_override && (user_latitude != TinyGPS::GPS_INVALID_F_ANGLE) && (user_longitude != TinyGPS::GPS_INVALID_F_ANGLE)){    
+
+  if(user_location_override && (user_latitude != TinyGPS::GPS_INVALID_F_ANGLE) && (user_longitude != TinyGPS::GPS_INVALID_F_ANGLE)){
     if(user_altitude != -1.0f){
       snprintf(gps_mqtt_string, GPS_MQTT_STRING_LENGTH-1, gps_lat_lng_alt_field_mqtt_template, user_latitude, user_longitude, user_altitude);
       snprintf(gps_csv_string, GPS_CSV_STRING_LENGTH-1, gps_lat_lng_alt_field_csv_template, user_latitude, user_longitude, user_altitude);
     }
-    else{      
+    else{
       snprintf(gps_mqtt_string, GPS_MQTT_STRING_LENGTH-1, gps_lat_lng_field_mqtt_template, user_latitude, user_longitude);
       snprintf(gps_csv_string, GPS_CSV_STRING_LENGTH-1, gps_lat_lng_field_csv_template, user_latitude, user_longitude);
-    }       
-  }  
+    }
+  }
   else if((gps_latitude != TinyGPS::GPS_INVALID_F_ANGLE) && (gps_longitude != TinyGPS::GPS_INVALID_F_ANGLE)){
     if(gps_altitude != TinyGPS::GPS_INVALID_F_ALTITUDE){
       snprintf(gps_mqtt_string, GPS_MQTT_STRING_LENGTH-1, gps_lat_lng_alt_field_mqtt_template, gps_latitude, gps_longitude, gps_altitude);
@@ -6171,9 +6171,9 @@ void updateGpsStrings(void){
     else{
       snprintf(gps_mqtt_string, GPS_MQTT_STRING_LENGTH-1, gps_lat_lng_field_mqtt_template, gps_latitude, gps_longitude);
       snprintf(gps_csv_string, GPS_CSV_STRING_LENGTH-1, gps_lat_lng_field_csv_template, gps_latitude, gps_longitude);
-    }    
+    }
   }
-  else{    
+  else{
     strcpy_P(gps_csv_string, PSTR(",---,---,---"));
   }
 }
@@ -6191,17 +6191,17 @@ void resumeGpsProcessing(void){
 /****** NTP SUPPORT FUNCTIONS ******/
 void getNetworkTime(void){
   const unsigned long connectTimeout  = 15L * 1000L; // Max time to wait for server connection
-  const unsigned long responseTimeout = 15L * 1000L; // Max time to wait for data from server  
-  char server[32] = {0};  
+  const unsigned long responseTimeout = 15L * 1000L; // Max time to wait for data from server
+  char server[32] = {0};
   eeprom_read_block(server, (void *) EEPROM_NTP_SERVER_NAME, 31);
   uint8_t       buf[48];
   unsigned long ip, startTime, t = 0L;
-  
+
   if(esp.getHostByName(server, &ip)) {
     static const char PROGMEM
       timeReqA[] = { 227,  0,  6, 236 },
       timeReqB[] = {  49, 78, 49,  52 };
-    
+
     Serial.print(F("Info: Getting NTP Time..."));
     startTime = millis();
     do {
@@ -6209,7 +6209,7 @@ void getNetworkTime(void){
     } while((!esp.connected()) &&
             ((millis() - startTime) < connectTimeout));
 
-    if(esp.connected()) {      
+    if(esp.connected()) {
       // Assemble and issue request packet
       memset(buf, 0, sizeof(buf));
       memcpy_P( buf    , timeReqA, sizeof(timeReqA));
@@ -6219,13 +6219,13 @@ void getNetworkTime(void){
       startTime = millis();
       while((esp.available() < 44) &&
             ((millis() - startTime) < responseTimeout));
-      
+
       if(esp.available() >= 44) {
         esp.read(buf, sizeof(buf));
         t = (((unsigned long)buf[40] << 24) |
              ((unsigned long)buf[41] << 16) |
              ((unsigned long)buf[42] <<  8) |
-              (unsigned long)buf[43]) - 2208988800UL;      
+              (unsigned long)buf[43]) - 2208988800UL;
       }
       esp.stop();
     }
@@ -6237,26 +6237,26 @@ void getNetworkTime(void){
     breakTime(t, tm);
     setTime(t);
 
-    selectSlot3();     
+    selectSlot3();
     DateTime datetime(t);
     rtc.adjust(datetime);
     rtcClearOscillatorStopFlag();
     selectNoSlot();
 
     memset(buf, 0, 48);
-    snprintf((char *) buf, 47, 
+    snprintf((char *) buf, 47,
       "%d/%d/%d",
       tm.Month,
       tm.Day,
       1970 + tm.Year);
-      
+
     clearLCD();
-    updateLCD((char *) buf, 0);    
-    
+    updateLCD((char *) buf, 0);
+
     Serial.print((char *) buf);
     Serial.print(" ");
     memset(buf, 0, 48);
-    snprintf((char *) buf, 47, 
+    snprintf((char *) buf, 47,
       "%02d:%02d:%02d",
       tm.Hour,
       tm.Minute,
@@ -6265,9 +6265,9 @@ void getNetworkTime(void){
     updateLCD((char *) buf, 1);
     Serial.println((char *) buf);
 
-    
-    SUCCESS_MESSAGE_DELAY(); 
-    
+
+    SUCCESS_MESSAGE_DELAY();
+
   }
   else{
     Serial.print(F("Failed."));
@@ -6283,12 +6283,12 @@ void clearCO2SerialInput(){
 
 boolean requestCO2Data(float * co2_ppm){
   uint8_t readCO2[] = {0xFE, 0x44, 0x00, 0x08, 0x02, 0x9F, 0x25};  // Command packet to read Co2 (see app note)
-  uint8_t response[] = {0,0,0,0,0,0,0};                            // Create an array to store the response    
+  uint8_t response[] = {0,0,0,0,0,0,0};                            // Create an array to store the response
   // try up to retry times
   const uint8_t retries = sizeof(readCO2);
-  
+
   for(uint8_t ii = 0; ii < retries; ii++){
-    if(co2SendRequest(readCO2)){                  
+    if(co2SendRequest(readCO2)){
       // there is the beginning of a response at least
       if(co2ConsumeResponse(response)){
         // there's a complete response at least
@@ -6297,7 +6297,7 @@ boolean requestCO2Data(float * co2_ppm){
           *co2_ppm = co2GetValue(response);
           return true;
         }
-      }  
+      }
     }
 
     // attempt to re-synchronize
@@ -6307,39 +6307,39 @@ boolean requestCO2Data(float * co2_ppm){
       // eventually the request message should be received by the sensor correctly
       co2Serial.write(0xff);
     }
-    
+
   }
-  
+
   Serial.print(F("Warning: Failed to collect CO2 Data"));
   return false;
 }
 
-// sends the request command 
+// sends the request command
 // returns true the sensor starts responding within 50ms
-boolean co2SendRequest(uint8_t * request){   
+boolean co2SendRequest(uint8_t * request){
   // before sending the command, take some steps
   // to ensure that that the input buffer is empty
   delay(50);
   clearCO2SerialInput();
-  
+
   co2Serial.write(request, 7);
   unsigned long start = millis();
-  const long timeout_interval = 50;  
+  const long timeout_interval = 50;
 
   while(1){
     unsigned long currentMillis = millis();
-    
-    if(co2Serial.available()){      
+
+    if(co2Serial.available()){
       // exit with true as soon as you get some bytes back
-      return true;   
+      return true;
     }
-    
-    if(currentMillis - start >= timeout_interval) {  
-      // exit with false if you get a timeout 
+
+    if(currentMillis - start >= timeout_interval) {
+      // exit with false if you get a timeout
       return false;
-    }           
+    }
   }
-  
+
   return false;
 }
 
@@ -6352,10 +6352,10 @@ boolean co2ConsumeResponse(uint8_t * response){
   const long timeout_interval = 100;
   while(bytes_received < 7){
     unsigned long currentMillis = millis();
-    if(currentMillis - start >= timeout_interval) {  
+    if(currentMillis - start >= timeout_interval) {
       return false;
     }
-    
+
     if(co2Serial.available()){
       uint8_t value = co2Serial.read();
       if((bytes_received == 0) && (value != 0xFE)){ // reject bytes until synchronized
@@ -6373,9 +6373,9 @@ boolean co2ConsumeResponse(uint8_t * response){
 uint16_t co2GetValue(uint8_t * response){
   uint8_t high = response[3]; // high byte for value is 4th byte in packet in the packet
   uint8_t low  = response[4]; // low byte for value is 5th byte in the packet
-  
-  uint16_t ret = high;  
-  ret <<= 8;   // shift the low byte into the high byte 
+
+  uint16_t ret = high;
+  ret <<= 8;   // shift the low byte into the high byte
   ret |= low;  // mask in the low byte
   return ret;  // return the result
 }
@@ -6383,8 +6383,8 @@ uint16_t co2GetValue(uint8_t * response){
 boolean co2ValidResponse(uint8_t * response){
   uint16_t crc = response[6] * 256 + response[5];
   if(co2_CRC16(response, 5) != crc){
-    Serial.print(F("Warning: CO2 Sensor CRC check failed"));    
-    Serial.println();    
+    Serial.print(F("Warning: CO2 Sensor CRC check failed"));
+    Serial.println();
     return false;
   }
 
@@ -6448,66 +6448,66 @@ uint16_t co2_CRC16 (const uint8_t *nData, uint16_t wLength)
 }
 
 /*
-void dump_config(uint8_t * buf){    
+void dump_config(uint8_t * buf){
   uint16_t addr = 0;
   uint8_t ii = 0;
   while(addr < EEPROM_CONFIG_MEMORY_SIZE){
     if(ii == 0){
       Serial.print(addr, HEX);
-      Serial.print(F(": ")); 
-    }    
-    
+      Serial.print(F(": "));
+    }
+
     Serial.print(buf[addr], HEX);
     Serial.print(F("\t"));
-    
+
     addr++;
     ii++;
     if(ii == 32){
       Serial.println();
-      ii = 0; 
+      ii = 0;
     }
   }
 }
 */
 
-void doSoftApModeConfigBehavior(void){  
+void doSoftApModeConfigBehavior(void){
   // if the user has opted out of soft ap mode, then don't do anything, just return
   if(eeprom_read_byte((const uint8_t *) EEPROM_DISABLE_SOFTAP) == 1){
     return;
   }
-  
+
   clearTempBuffers();
-  
+
   randomSeed(micros());
-  char random_password[16] = {0}; 
+  char random_password[16] = {0};
   strcpy(random_password, ""); // could use a fixed prefix by initializing it here
   uint8_t fixed_password_length = strlen(random_password);
   const uint8_t random_password_length = 8;
-    
+
   static const char whitelist[] PROGMEM = {
-    '2',  '3',  '4',  '5',  '6',  '7',  '8',  '9',  
-//    'A',  'B',  'C',  'D',  'E',  'F',  'G',  'H',  
+    '2',  '3',  '4',  '5',  '6',  '7',  '8',  '9',
+//    'A',  'B',  'C',  'D',  'E',  'F',  'G',  'H',
 //    'J',  'K',  'L',  'M',  'N',  'P',  'R',  'S',
-//    'T',  'U',  'V',  'W',  'X',  'Y',  'Z',  'a',  
-    'a', 'b',  'c',  'd',  'e',  'f',  'g',  'h',  'i',  
-//    'j',  'k',  'm',  'n',  'o',  'p',  'q',  'r',  
-    'j',  'k',  'm',  'n',  'o',  'p',  'r',  
+//    'T',  'U',  'V',  'W',  'X',  'Y',  'Z',  'a',
+    'a', 'b',  'c',  'd',  'e',  'f',  'g',  'h',  'i',
+//    'j',  'k',  'm',  'n',  'o',  'p',  'q',  'r',
+    'j',  'k',  'm',  'n',  'o',  'p',  'r',
     's',  't',  'u',  'v',  'w',  'x',  'y',  'z'
   };
   uint8_t _mac_address[6] = {0};
   eeprom_read_block((void *)_mac_address, (const void *) EEPROM_MAC_ADDRESS, 6);
   char egg_ssid[16] = {0};
-  sprintf(egg_ssid, "egg-%02x%02x%02x", _mac_address[3], _mac_address[4], _mac_address[5]);  
+  sprintf(egg_ssid, "egg-%02x%02x%02x", _mac_address[3], _mac_address[4], _mac_address[5]);
 
   uint8_t ii = fixed_password_length;
   while(ii < random_password_length){
     uint8_t idx = random(0, 'z' - '0' + 1);
-    char c = (char) ('0' + idx); 
-    
+    char c = (char) ('0' + idx);
+
     // if it's in the white list allow it
     boolean in_whitelist = false;
     for(uint8_t jj = 0; jj < sizeof(whitelist); jj++){
-      char wl_char = pgm_read_byte(&(whitelist[jj]));      
+      char wl_char = pgm_read_byte(&(whitelist[jj]));
       if(wl_char == c){
         in_whitelist = true;
         break;
@@ -6515,62 +6515,62 @@ void doSoftApModeConfigBehavior(void){
     }
 
     if(in_whitelist){
-      random_password[ii++] = c;     
-      random_password[ii] = NULL;     
+      random_password[ii++] = c;
+      random_password[ii] = NULL;
     }
   }
 
   clearLCD();
-  updateLCD(egg_ssid, 0);   
+  updateLCD(egg_ssid, 0);
   updateLCD(&random_password[fixed_password_length], 1);
 
-  const uint32_t default_seconds_remaining_in_softap_mode = 5UL * 60UL; // stay in softap for 5 minutes max  
+  const uint32_t default_seconds_remaining_in_softap_mode = 5UL * 60UL; // stay in softap for 5 minutes max
   uint32_t seconds_remaining_in_softap_mode = default_seconds_remaining_in_softap_mode;
-  
+
   boolean explicit_exit_softap = false;
   const uint16_t softap_http_port = 80;
   char ssid[33] = {0};
   char pwd[33] = {0};
-  
+
   if(esp.setNetworkMode(3)){ // means softAP mode
-    Serial.println(F("Info: Enabled Soft AP"));    
-    if(esp.configureSoftAP(egg_ssid, random_password, 5, 3)){ // channel = 5, sec = WPA      
+    Serial.println(F("Info: Enabled Soft AP"));
+    if(esp.configureSoftAP(egg_ssid, random_password, 5, 3)){ // channel = 5, sec = WPA
       // open a port and listen for config data messages, for up to two minutes
       if(esp.listen(softap_http_port)){
         Serial.print(F("Info: Listening for connections on port "));
         Serial.print(softap_http_port);
         Serial.println(F("..."));
         Serial.print(F("Info: SoftAP password is \""));
-        Serial.print(random_password);        
+        Serial.print(random_password);
         Serial.println(F("\""));
-        
+
         unsigned long previousMillis = 0;
-        const long interval = 1000;                
-        boolean got_opening_brace = false;        
+        const long interval = 1000;
+        boolean got_opening_brace = false;
         boolean got_closing_brace = false;
-                
+
         while((seconds_remaining_in_softap_mode != 0) && (!explicit_exit_softap)){
           unsigned long currentMillis = millis();
 
-          if (currentMillis - previousMillis >= interval) {                        
+          if (currentMillis - previousMillis >= interval) {
             previousMillis = currentMillis;
             if(seconds_remaining_in_softap_mode != 0){
               seconds_remaining_in_softap_mode--;
-              Serial.print(".");       
-              updateCornerDot();                    
+              Serial.print(".");
+              updateCornerDot();
               if((seconds_remaining_in_softap_mode % 60) == 0){
                 Serial.println();
               }
-            }                        
-            petWatchdog();            
+            }
+            petWatchdog();
           }
 
           // check backlight touch
-          if(currentMillis - previous_touch_sampling_millis >= touch_sampling_interval){              
-            previous_touch_sampling_millis = currentMillis;    
-            collectTouch();    
-            processTouchQuietly();                            
-          }      
+          if(currentMillis - previous_touch_sampling_millis >= touch_sampling_interval){
+            previous_touch_sampling_millis = currentMillis;
+            collectTouch();
+            processTouchQuietly();
+          }
 
           // check to determine if we have a GPS
           while(!gps_installed && gpsSerial.available()){
@@ -6579,39 +6579,39 @@ void doSoftApModeConfigBehavior(void){
               gps_installed = true;
             }
           }
-          
-          // pay attention to incoming traffic          
+
+          // pay attention to incoming traffic
           while(esp.available()){
             char c = esp.read();
             if(got_opening_brace){
               if(c == '}'){
-                got_closing_brace = true;    
+                got_closing_brace = true;
                 scratch[scratch_idx++] = c;
                 break;
               }
               else{
                 if(scratch_idx < SCRATCH_BUFFER_SIZE - 1){
-                  scratch[scratch_idx++] = c;                  
+                  scratch[scratch_idx++] = c;
                 }
                 else{
                   Serial.println("Warning: scratch buffer out of memory");
                 }
               }
             }
-            else if(c == '{'){              
+            else if(c == '{'){
               got_opening_brace = true;
               scratch[scratch_idx++] = c;
-            }            
-          }                     
+            }
+          }
 
           if(got_closing_brace){
             // Serial.println("Message Body: ");
-            // Serial.println(scratch);  
-            
-            // send back an HTTP response 
+            // Serial.println(scratch);
+
+            // send back an HTTP response
             // Then send a few headers to identify the type of data returned and that
-            // the connection will not be held open.                            
-            char response_template[] PROGMEM = "HTTP/1.1 200 OK\r\n"         
+            // the connection will not be held open.
+            char response_template[] PROGMEM = "HTTP/1.1 200 OK\r\n"
               "Content-Type: application/json; charset=utf-8\r\n"
               "Connection: close\r\n"
               "Server: air quality egg\r\n"
@@ -6619,8 +6619,8 @@ void doSoftApModeConfigBehavior(void){
               "Access-Control-Allow-Origin: *\r\n"
               "\r\n"
               "%s";
-            
-            const char response_body_template[] PROGMEM = 
+
+            const char response_body_template[] PROGMEM =
               "{"
                "\"sn\":\"%s\","
                "\"model\":\"%s\","
@@ -6636,19 +6636,19 @@ void doSoftApModeConfigBehavior(void){
                "\"lat\":%s,"
                "\"lng\":%s,"
                "\"alt\":%s"
-              "}";            
-                                       
+              "}";
+
             char serial_number[32] = {0};
             char ssid[33] = {0};
             char userLat[16] = {0};
             char userLng[16] = {0};
-            char userAlt[16] = {0};  
-            char operational_mode[16] = {0};  
-            
+            char userAlt[16] = {0};
+            char operational_mode[16] = {0};
+
             if(parseConfigurationMessageBody(scratch)){
-              explicit_exit_softap = true;              
+              explicit_exit_softap = true;
             }
-            
+
             eeprom_read_block(serial_number, (const void *) EEPROM_MQTT_CLIENT_ID, 31);
             eeprom_read_block(ssid, (const void *) EEPROM_SSID, 32);
 
@@ -6668,26 +6668,26 @@ void doSoftApModeConfigBehavior(void){
             else{
               strcpy(operational_mode, "unknown");
             }
-            
+
             floatToJsString(f_alt, userAlt, 2);
             floatToJsString(eeprom_read_float((float *) EEPROM_USER_LATITUDE_DEG), userLat, 6);
             floatToJsString(eeprom_read_float((float *) EEPROM_USER_LONGITUDE_DEG), userLng, 6);
-            
+
             const char model_type[] = "D";
             const char true_string[] = "true";
             const char false_string[] = "false";
-            
+
             char * hasGPS = gps_installed ? (char *) true_string : (char *) false_string;
             char * useGPS = user_location_override ? (char *) false_string : (char *) true_string;
             char * wifiConn = wifi_can_connect ? (char *) true_string : (char *) false_string;
             char * hasSD = init_sdcard_ok ? (char *) true_string : (char *) false_string;
-                        
-            char tempUnit[2] = {0};
-            tempUnit[0] = eeprom_read_byte((const uint8_t *) EEPROM_TEMPERATURE_UNITS);          
 
-            clearTempBuffers();   
-            
-            sprintf(response_body, response_body_template, 
+            char tempUnit[2] = {0};
+            tempUnit[0] = eeprom_read_byte((const uint8_t *) EEPROM_TEMPERATURE_UNITS);
+
+            clearTempBuffers();
+
+            sprintf(response_body, response_body_template,
               serial_number,
               model_type,
               AQEV2FW_MAJOR_VERSION,
@@ -6704,44 +6704,44 @@ void doSoftApModeConfigBehavior(void){
               userLat,
               userLng,
               userAlt
-              );             
-                                           
-            sprintf(scratch, response_template, strlen(response_body), response_body);            
-            
+              );
+
+            sprintf(scratch, response_template, strlen(response_body), response_body);
+
             // Serial.print("Responding With: ");
-            // Serial.println(scratch);  
+            // Serial.println(scratch);
             esp.print(scratch);
             seconds_remaining_in_softap_mode = default_seconds_remaining_in_softap_mode;
-            
+
             // and wait 100ms to make sure it gets back to the caller
-            delay(100); 
+            delay(100);
             esp.stop();
-            
-            clearTempBuffers();                 
+
+            clearTempBuffers();
             // if the parse failed we're back to waiting for a message body
             got_closing_brace = false;
-            got_opening_brace = false;       
-            
+            got_opening_brace = false;
+
 //            clearLCD();
-//            updateLCD(egg_ssid, 0);   
-//            updateLCD(&random_password[fixed_password_length], 1);  
+//            updateLCD(egg_ssid, 0);
+//            updateLCD(&random_password[fixed_password_length], 1);
 //
-//            clearTempBuffers();                               
-          }          
-        }        
+//            clearTempBuffers();
+          }
+        }
       }
       else{
         Serial.print(F("Error: Failed to start TCP server on port "));
         Serial.println(softap_http_port);
-      }    
+      }
     }
     else{
       Serial.println(F("Error: Failed to configure Soft AP"));
     }
   }
   else{
-    Serial.println(F("Error: Failed to start Soft AP Mode"));  
-  }  
+    Serial.println(F("Error: Failed to start Soft AP Mode"));
+  }
 
   Serial.println(F("Info: Exiting SoftAP Mode"));
 }
@@ -6758,13 +6758,13 @@ void floatToJsString(float f, char * target, uint8_t digits_after_decimal_point)
   else{
     char format_string[] = "%.0f";                  // initialize digits after decimal point to 0
     format_string[2] += digits_after_decimal_point; // update the digits after decimal point
-    sprintf(target, format_string, f);     
+    sprintf(target, format_string, f);
   }
 }
 
 boolean parseConfigurationMessageBody(char * body){
   jsmn_init(&parser);
-  
+
   boolean found_ssid = false;
   boolean found_pwd = false;
   boolean handled_ssid_pwd = false;
@@ -6786,15 +6786,15 @@ boolean parseConfigurationMessageBody(char * body){
   char value[33] = {0};
   char ssid[33] = {0};
   char pwd[33] = {0};
-  
-  for(uint8_t ii = 1; ii < r; ii+=2){    
+
+  for(uint8_t ii = 1; ii < r; ii+=2){
     memset(key, 0, 33);
     memset(value, 0, 33);
     uint16_t keylen = json_tokens[ii].end - json_tokens[ii].start;
     uint16_t valuelen = json_tokens[ii+1].end - json_tokens[ii+1].start;
 
     if(keylen <= 32){
-      strncpy(key, body + json_tokens[ii].start, keylen);      
+      strncpy(key, body + json_tokens[ii].start, keylen);
     }
 
     if(valuelen <= 32){
@@ -6805,7 +6805,7 @@ boolean parseConfigurationMessageBody(char * body){
      Serial.print(key);
      Serial.print(" => ");
      Serial.print(value);
-     Serial.println();   
+     Serial.println();
 
     // handlers for valid JSON keys
     if(strcmp(key, "ssid") == 0){
@@ -6854,21 +6854,21 @@ boolean parseConfigurationMessageBody(char * body){
       wifi_connect_attempts++;
 
       set_ssid(ssid);
-      set_network_password(pwd);     
-      set_network_security_mode("auto");      
-      
-      if(esp.connectToNetwork((char *) ssid, (char *) pwd, 30000)){              
+      set_network_password(pwd);
+      set_network_security_mode("auto");
+
+      if(esp.connectToNetwork((char *) ssid, (char *) pwd, 30000)){
         Serial.print(F("Info: Successfully connected to Network \""));
         Serial.print(ssid);
         Serial.print(F("\""));
         Serial.println();
-        wifi_can_connect = true;      
+        wifi_can_connect = true;
       }
       else{
         Serial.print(F("Info: Unable to connect to Network \""));
         Serial.print(ssid);
         Serial.print(F("\""));
-        Serial.println();        
+        Serial.println();
         wifi_can_connect = false;
       }
       handled_ssid_pwd = true;
@@ -6876,8 +6876,8 @@ boolean parseConfigurationMessageBody(char * body){
   }
 
   // commit changes, because it's annoying to lose settings because of an Egg reset
-  if(!mirrored_config_matches_eeprom_config()){   
-    if(checkConfigIntegrity()){              
+  if(!mirrored_config_matches_eeprom_config()){
+    if(checkConfigIntegrity()){
       commitConfigToMirroredConfig();
     }
   }


### PR DESCRIPTION
This PR adds:
 * SoftAP mode that can be entered at startup by touch.
   * supports a limited subset of the CLI-configurable options on the Egg, most notably ssid and password
   * but also, lat, lng, alt, use_gps, temp_unit, exit
 * Adds a user-location-override concept so that a user can declare their latitude, longitude (and altitude), and can decide whether to give precedence to these settings in the presence of an installed GPS.
   * commands added: latitude, longitude, location
   * also use GPS altitude in pressure correction calculations if it's available
 * Start-up behavior modified to give priority to SoftAP mode as fallback path in "un-configured" (e.g. default or corrupted) state, and to still always give the opportunity to get into CLI mode (i.e. always include 12-second count down at startup).
 * Some minor console log changes to be less confusing, e.g. on wi-fi scan having no rssi results.
 * reduced maximum sample depth from 240 to 180 to free RAM for SoftAP functionality.
 * removed detailed help from CLI to recover memory and make space for SoftAP functionality
   * Note: may add that back in, in a future release by storing the help files on SD card
 * Modifies backlight behavior to be on throughout startup (if not disabled by user config)
 * Sensor values are displayed in offline mode
 * Note: relies on updates to related library: https://github.com/wickeddevice/ESP8266_AT_CLIENT
 * Rolls minor firmware version to 2.2.0
   * this PR adds functionality in a backwards compatible way (obviously debatable in some respects).